### PR TITLE
add the base Runner; add params-related task helper methods

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,0 +1,22 @@
+module Dk
+
+  class Runner
+
+    attr_reader :task_class, :task, :params
+
+    def initialize(task_class, args = nil)
+      args ||= {}
+      @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
+      @params.merge!(args[:params] || {})
+
+      @task_class = task_class
+      @task = @task_class.new(self)
+    end
+
+    def run
+      raise NotImplementedError
+    end
+
+  end
+
+end

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -13,6 +13,13 @@ module Dk
 
     module InstanceMethods
 
+      def initialize(runner, params = nil)
+        params ||= {}
+        @dk_runner = runner
+        @dk_params = Hash.new{ |h, k| @dk_runner.params[k] }
+        @dk_params.merge!(params)
+      end
+
       def dk_run
         # self.dk_run_callbacks 'before_run'
         self.run!
@@ -21,6 +28,16 @@ module Dk
 
       def run!
         raise NotImplementedError
+      end
+
+      private
+
+      # Helpers
+
+      def params; @dk_params; end
+
+      def set_param(key, value)
+        @dk_runner.params[key] = value
       end
 
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,0 +1,62 @@
+require 'assert'
+require 'dk/runner'
+
+require 'dk/task'
+
+class Dk::Runner
+
+  class UnitTests < Assert::Context
+    desc "Dk::Runner"
+    setup do
+      @runner_class = Dk::Runner
+    end
+    subject{ @runner_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @task_class = TestTask
+      @runner = @runner_class.new(@task_class)
+    end
+    subject{ @runner }
+
+    should have_readers :task_class, :task, :params
+    should have_imeths :run
+
+    should "know its task class and task" do
+      assert_equal @task_class, subject.task_class
+      assert_instance_of @task_class, subject.task
+    end
+
+    should "default its attrs" do
+      assert_equal({}, subject.params)
+    end
+
+    should "know its attrs" do
+      args = {
+        :params => { Factory.string => Factory.string }
+      }
+      runner = @runner_class.new(@task_class, args)
+
+      assert_equal args[:params],  runner.params
+    end
+
+    should "use params that complain when accessing missing keys" do
+      key = Factory.string
+      assert_raises(ArgumentError){ subject.params[key] }
+
+      subject.params[key] = Factory.string
+      assert_nothing_raised{ subject.params[key] }
+    end
+
+    should "not implement its run method" do
+      assert_raises(NotImplementedError){ subject.run }
+    end
+
+  end
+
+  TestTask = Class.new{ include Dk::Task }
+
+end


### PR DESCRIPTION
This implements the basic Runner for running tasks.  This is a
base for building more specific runners for more specific cases:
running in tests, running dry-runs, etc.  The runner stores the
params for each task it runs.  This adds the params-related
runner logic and also adds two params-related helper methods
to the task.

The params is a Hash that errors if unknown keys are requested.
The goal here is to be noisy and alert the developer if they are
asking for a param that hasn't been set.  The params are built
from any given when the runner is created.  Eventually, the
runners will be built using a global config's params.

The task now has a `params` helper method for accessing the
params.  Task's can also be built using any given custom params
but fall back to the runner's params.  The task also now has a
`set_param` method that allows a task to set runner-level params.
This allows you to create tasks that just configure params on
the runner that change the behavior of other tasks.

@jcredding ready for review.
