### PR TITLE
`run_task` task helper method

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -2,18 +2,15 @@ module Dk
 
   class Runner
 
-    attr_reader :task_class, :task, :params
+    attr_reader :params
 
-    def initialize(task_class, args = nil)
+    def initialize(args = nil)
       args ||= {}
       @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
       @params.merge!(args[:params] || {})
-
-      @task_class = task_class
-      @task = @task_class.new(self)
     end
 
-    def run
+    def run(task_class, params = nil)
       raise NotImplementedError
     end
 

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -40,6 +40,10 @@ module Dk
         @dk_runner.params[key] = value
       end
 
+      def run_task(task_class, params = nil)
+        @dk_runner.run(task_class, params)
+      end
+
     end
 
     module ClassMethods

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -17,18 +17,12 @@ class Dk::Runner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @task_class = TestTask
-      @runner = @runner_class.new(@task_class)
+      @runner = @runner_class.new
     end
     subject{ @runner }
 
-    should have_readers :task_class, :task, :params
+    should have_readers :params
     should have_imeths :run
-
-    should "know its task class and task" do
-      assert_equal @task_class, subject.task_class
-      assert_instance_of @task_class, subject.task
-    end
 
     should "default its attrs" do
       assert_equal({}, subject.params)
@@ -38,9 +32,9 @@ class Dk::Runner
       args = {
         :params => { Factory.string => Factory.string }
       }
-      runner = @runner_class.new(@task_class, args)
+      runner = @runner_class.new(args)
 
-      assert_equal args[:params],  runner.params
+      assert_equal args[:params], runner.params
     end
 
     should "use params that complain when accessing missing keys" do
@@ -52,7 +46,7 @@ class Dk::Runner
     end
 
     should "not implement its run method" do
-      assert_raises(NotImplementedError){ subject.run }
+      assert_raises(NotImplementedError){ subject.run(TestTask) }
     end
 
   end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -36,10 +36,10 @@ module Dk::Task
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @runner = Dk::Runner.new(@task_class, {
+      @runner = Dk::Runner.new({
         :params => { Factory.string => Factory.string }
       })
-      @task = @runner.task
+      @task = @task_class.new(@runner)
     end
     subject{ @task }
 
@@ -49,6 +49,19 @@ module Dk::Task
       assert_raises NotImplementedError do
         subject.run!
       end
+    end
+
+    should "run other tasks by calling the runner's run method" do
+      runner_run_called_with = nil
+      Assert.stub(@runner, :run){ |*args| runner_run_called_with = args }
+
+      other_task_class  = Class.new{ include Dk::Task }
+      other_task_params = { Factory.string => Factory.string }
+
+      subject.instance_eval{ run_task(other_task_class, other_task_params) }
+
+      exp = [other_task_class, other_task_params]
+      assert_equal exp, runner_run_called_with
     end
 
   end


### PR DESCRIPTION
This adds a `run_task` helper method to tasks.  Use this method
to run tasks from other tasks.

Included in this change is a reworking of how the runner interacts
with tasks:
- FACT: the runner no longer takes a single task class and builds
  a single task.
- FACT: the runner's `run` method now takes a task class and
  optional parameters.  This allows a single runner to run many
  tasks by making a run call for each task it needs to run.
- FACT: The specific runners will each implement their own specific
  run behavior in future efforts.
- FACT: The original implementation was short-sided as the intent
  was always that a single runner could run many.
- FACT: the `run_task` helper method calls the `run` method on the
  runner.  This allows for common run behavior when running sub
  tasks.

@jcredding ready for review.
