### PR TITLE
stringify runner params

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -7,11 +7,34 @@ module Dk
     def initialize(args = nil)
       args ||= {}
       @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
-      @params.merge!(args[:params] || {})
+      @params.merge!(normalize_params(args[:params]))
     end
 
     def run(task_class, params = nil)
       raise NotImplementedError
+    end
+
+    def set_param(key, value)
+      @params.merge!(normalize_params({ key => value }))
+    end
+
+    private
+
+    def normalize_params(params)
+      StringifyParams.new(params || {})
+    end
+
+    module StringifyParams
+      def self.new(object)
+        case(object)
+        when ::Hash
+          object.inject({}){ |h, (k, v)| h.merge(k.to_s => self.new(v)) }
+        when ::Array
+          object.map{ |item| self.new(item) }
+        else
+          object
+        end
+      end
     end
 
   end

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -34,10 +34,12 @@ module Dk
 
       # Helpers
 
-      def params; @dk_params; end
+      def params
+        @dk_params
+      end
 
       def set_param(key, value)
-        @dk_runner.params[key] = value
+        @dk_runner.set_param(key, value)
       end
 
       def run_task(task_class, params = nil)

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -22,7 +22,7 @@ class Dk::Runner
     subject{ @runner }
 
     should have_readers :params
-    should have_imeths :run
+    should have_imeths :run, :set_param
 
     should "default its attrs" do
       assert_equal({}, subject.params)
@@ -43,6 +43,23 @@ class Dk::Runner
 
       subject.params[key] = Factory.string
       assert_nothing_raised{ subject.params[key] }
+    end
+
+    should "stringify the params passed to it" do
+      key, value = Factory.string.to_sym, Factory.string
+      params = { key => [{ key => value }] }
+      runner = @runner_class.new(:params => params)
+
+      exp = { key.to_s => [{ key.to_s => value }] }
+      assert_equal exp, runner.params
+    end
+
+    should "stringify and set param values with `set_param`" do
+      key, value = Factory.string.to_sym, Factory.string
+      subject.set_param(key, value)
+
+      assert_equal value, subject.params[key.to_s]
+      assert_raises(ArgumentError){ subject.params[key] }
     end
 
     should "not implement its run method" do

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -85,13 +85,24 @@ module Dk::Task
       @task_params = { Factory.string => Factory.string }
     end
 
-    should "call to the runner for its params" do
+    should "call to the runner for `params`" do
       p = @runner.params.keys.first
       assert_equal @runner.params[p], subject.instance_eval{ params[p] }
 
       assert_raises(ArgumentError) do
         subject.instance_eval{ params[Factory.string] }
       end
+    end
+
+    should "call to the runner for `set_param`" do
+      set_param_called_with = nil
+      Assert.stub(@runner, :set_param){ |*args| set_param_called_with = args }
+
+      key, value = Factory.string, Factory.string
+      subject.instance_eval{ set_param(key, value) }
+
+      exp = [key, value]
+      assert_equal exp, set_param_called_with
     end
 
     should "merge any given task params" do


### PR DESCRIPTION
This ensures that no matter how the param key was set, you access
it commonly with string keys.

Note: to commonize this properly, I needed the runner to implement
the stringify function and have all runner params writing go
through the runner (ie the `set_param` method).  This should have
been done originally as all meaningful logic should be controlled
and commonized by the runner but was missed in the previous
effort.

@jcredding ready for review.
