### PR TITLE
setup the runner; break out runner API for running sub-tasks

### DIFF
--- a/lib/dk/dk_runner.rb
+++ b/lib/dk/dk_runner.rb
@@ -1,0 +1,8 @@
+require 'dk/runner'
+
+module Dk
+
+  class DkRunner < Runner
+  end
+
+end

--- a/lib/dk/dry_runner.rb
+++ b/lib/dk/dry_runner.rb
@@ -1,0 +1,11 @@
+require 'dk/runner'
+
+module Dk
+
+  class DryRunner < Runner
+
+    # TODO: disable any cmds, just log actions, but run all sub-tasks
+
+  end
+
+end

--- a/lib/dk/has_the_runs.rb
+++ b/lib/dk/has_the_runs.rb
@@ -1,0 +1,23 @@
+require 'much-plugin'
+
+module Dk
+
+  module HasTheRuns
+    include MuchPlugin
+
+    plugin_included do
+      include InstanceMethods
+
+    end
+
+    module InstanceMethods
+
+      def runs
+        @runs ||= []
+      end
+
+    end
+
+  end
+
+end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -10,8 +10,14 @@ module Dk
       @params.merge!(normalize_params(args[:params]))
     end
 
+    # called by CLI on top-level tasks
     def run(task_class, params = nil)
-      raise NotImplementedError
+      build_and_run_task(task_class, params)
+    end
+
+    # called by other tasks on sub-tasks
+    def run_task(task_class, params = nil)
+      build_and_run_task(task_class, params)
     end
 
     def set_param(key, value)
@@ -19,6 +25,10 @@ module Dk
     end
 
     private
+
+    def build_and_run_task(task_class, params = nil)
+      task_class.new(self, params).tap(&:dk_run)
+    end
 
     def normalize_params(params)
       StringifyParams.new(params || {})

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -43,7 +43,7 @@ module Dk
       end
 
       def run_task(task_class, params = nil)
-        @dk_runner.run(task_class, params)
+        @dk_runner.run_task(task_class, params)
       end
 
     end

--- a/lib/dk/task_run.rb
+++ b/lib/dk/task_run.rb
@@ -1,0 +1,17 @@
+require 'dk/has_the_runs'
+
+module Dk
+
+  class TaskRun
+    include HasTheRuns
+
+    attr_reader :task_class, :params
+
+    def initialize(task_class, params)
+      @task_class = task_class
+      @params     = params
+    end
+
+  end
+
+end

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -1,0 +1,21 @@
+require 'dk/has_the_runs'
+require 'dk/runner'
+require 'dk/task_run'
+
+module Dk
+
+  class TestRunner < Runner
+    include HasTheRuns
+
+    # don't run any sub-tasks, just track that a sub-task was run
+    def run_task(task_class, params = nil)
+      self.runs << TaskRun.new(task_class, params)
+    end
+
+    # TODO: don't run any cmds, just track that a cmd was run
+
+    # TODO: disable any logging
+
+  end
+
+end

--- a/lib/dk/tree_runner.rb
+++ b/lib/dk/tree_runner.rb
@@ -1,0 +1,37 @@
+require 'dk/dry_runner'
+require 'dk/has_the_runs'
+require 'dk/task_run'
+
+module Dk
+
+  class TreeRunner < DryRunner
+    include HasTheRuns
+
+    def initialize(*args)
+      super
+      @task_run_stack = [self]
+    end
+
+    def run(*args)
+      super
+      # TODO: log out view of nested task runs
+    end
+
+    # TODO: disable any logging
+
+    private
+
+    # track all task runs
+    def build_and_run_task(task_class, params = nil)
+      task_run = TaskRun.new(task_class, params)
+      @task_run_stack.last.runs << task_run
+
+      @task_run_stack.push(task_run)
+      task = super(task_class, params)
+      @task_run_stack.pop
+      task
+    end
+
+  end
+
+end

--- a/test/unit/dk_runner_tests.rb
+++ b/test/unit/dk_runner_tests.rb
@@ -1,0 +1,21 @@
+require 'assert'
+require 'dk/dk_runner'
+
+require 'dk/runner'
+
+class Dk::DkRunner
+
+  class UnitTests < Assert::Context
+    desc "Dk::DkRunner"
+    setup do
+      @runner_class = Dk::DkRunner
+    end
+    subject{ @runner_class }
+
+    should "be a Dk::Runner" do
+      assert_true subject < Dk::Runner
+    end
+
+  end
+
+end

--- a/test/unit/dry_runner_tests.rb
+++ b/test/unit/dry_runner_tests.rb
@@ -1,0 +1,21 @@
+require 'assert'
+require 'dk/dry_runner'
+
+require 'dk/runner'
+
+class Dk::DryRunner
+
+  class UnitTests < Assert::Context
+    desc "Dk::DryRunner"
+    setup do
+      @runner_class = Dk::DryRunner
+    end
+    subject{ @runner_class }
+
+    should "be a Dk::Runner" do
+      assert_true subject < Dk::Runner
+    end
+
+  end
+
+end

--- a/test/unit/has_the_runs_tests.rb
+++ b/test/unit/has_the_runs_tests.rb
@@ -1,0 +1,37 @@
+require 'assert'
+require 'dk/has_the_runs'
+
+require 'much-plugin'
+
+module Dk::HasTheRuns
+
+  class UnitTests < Assert::Context
+    desc "Dk::HasTheRuns"
+    setup do
+      @mixin_class = Dk::HasTheRuns
+      @runs_class  = Class.new{ include Dk::HasTheRuns }
+    end
+    subject{ @mixin_class }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runs = @runs_class.new
+    end
+    subject{ @runs }
+
+    should have_imeths :runs
+
+    should "have no runs by default" do
+      assert_equal [], subject.runs
+    end
+
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -62,12 +62,38 @@ class Dk::Runner
       assert_raises(ArgumentError){ subject.params[key] }
     end
 
-    should "not implement its run method" do
-      assert_raises(NotImplementedError){ subject.run(TestTask) }
+    should "build and run a given task class" do
+      params = { Factory.string => Factory.string }
+
+      task = subject.run(TestTask)
+      assert_true task.run_called
+      assert_equal Hash.new, task.run_params
+
+      task = subject.run(TestTask, params)
+      assert_true task.run_called
+      assert_equal params, task.run_params
+
+      task = subject.run_task(TestTask)
+      assert_true task.run_called
+      assert_equal Hash.new, task.run_params
+
+      task = subject.run_task(TestTask, params)
+      assert_true task.run_called
+      assert_equal params, task.run_params
     end
 
   end
 
-  TestTask = Class.new{ include Dk::Task }
+  class TestTask
+    include Dk::Task
+
+    attr_reader :run_called, :run_params
+
+    def run!
+      @run_called = true
+      @run_params = params
+    end
+
+  end
 
 end

--- a/test/unit/task_run_tests.rb
+++ b/test/unit/task_run_tests.rb
@@ -1,0 +1,40 @@
+require 'assert'
+require 'dk/task_run'
+
+require 'dk/has_the_runs'
+
+class Dk::TaskRun
+
+  class UnitTests < Assert::Context
+    desc "Dk::TaskRun"
+    setup do
+      @task_run_class = Dk::TaskRun
+    end
+    subject{ @task_run_class }
+
+    should "have the runs" do
+      assert_includes Dk::HasTheRuns, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @task_class = Factory.string
+      @params     = { Factory.string => Factory.string }
+
+      @task_run = @task_run_class.new(@task_class, @params)
+    end
+    subject{ @task_run }
+
+    should have_imeths :task_class, :params
+
+    should "know its task class and params" do
+      assert_equal @task_class, subject.task_class
+      assert_equal @params,     subject.params
+    end
+
+  end
+
+end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -51,9 +51,9 @@ module Dk::Task
       end
     end
 
-    should "run other tasks by calling the runner's run method" do
-      runner_run_called_with = nil
-      Assert.stub(@runner, :run){ |*args| runner_run_called_with = args }
+    should "run other tasks by calling the runner's `run_task` method" do
+      runner_run_task_called_with = nil
+      Assert.stub(@runner, :run_task){ |*args| runner_run_task_called_with = args }
 
       other_task_class  = Class.new{ include Dk::Task }
       other_task_params = { Factory.string => Factory.string }
@@ -61,7 +61,7 @@ module Dk::Task
       subject.instance_eval{ run_task(other_task_class, other_task_params) }
 
       exp = [other_task_class, other_task_params]
-      assert_equal exp, runner_run_called_with
+      assert_equal exp, runner_run_task_called_with
     end
 
   end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -1,0 +1,97 @@
+require 'assert'
+require 'dk/test_runner'
+
+require 'dk/has_the_runs'
+require 'dk/runner'
+require 'dk/task'
+require 'dk/task_run'
+
+class Dk::TestRunner
+
+  class UnitTests < Assert::Context
+    desc "Dk::TestRunner"
+    setup do
+      @runner_class = Dk::TestRunner
+    end
+    subject{ @runner_class }
+
+    should "be a Dk::Runner" do
+      assert_true subject < Dk::Runner
+    end
+
+    should "have the runs" do
+      assert_includes Dk::HasTheRuns, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner = @runner_class.new
+    end
+    subject{ @runner }
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @params = { Factory.string => Factory.string }
+      @task = @runner.run(TestTask, @params)
+    end
+    subject{ @task }
+
+    should "run the task with any given params" do
+      assert_true subject.run_called
+      assert_equal @params, subject.run_params
+    end
+
+    should "capture any sub-tasks that were run but not actually run them" do
+      assert_equal 1, @runner.runs.size
+
+      sub_task_run = @runner.runs.first
+      assert_equal TestTask::SubTask,       sub_task_run.task_class
+      assert_equal subject.sub_task_params, sub_task_run.params
+      assert_equal [],                      sub_task_run.runs
+    end
+
+  end
+
+  class TestTask
+    include Dk::Task
+
+    attr_reader :run_called, :run_params
+    attr_reader :sub_task_params
+
+    def run!
+      @run_called = true
+      @run_params = params
+
+      @sub_task_params = { Factory.string => Factory.string }
+      run_task(SubTask, @sub_task_params)
+    end
+
+    class SubTask
+      include Dk::Task
+
+      attr_reader :run_called, :run_params
+
+      def run!
+        @run_called = true
+        @run_params = params
+        run_task(SubSubTask)
+      end
+    end
+
+    class SubSubTask
+      include Dk::Task
+
+      def run!
+        # no-op
+      end
+    end
+
+  end
+
+end

--- a/test/unit/tree_runner_tests.rb
+++ b/test/unit/tree_runner_tests.rb
@@ -1,0 +1,124 @@
+require 'assert'
+require 'dk/tree_runner'
+
+require 'dk/has_the_runs'
+require 'dk/dry_runner'
+require 'dk/task'
+require 'dk/task_run'
+
+class Dk::TreeRunner
+
+  class UnitTests < Assert::Context
+    desc "Dk::TreeRunner"
+    setup do
+      @runner_class = Dk::TreeRunner
+    end
+    subject{ @runner_class }
+
+    should "be a Dk::DryRunner" do
+      assert_true subject < Dk::DryRunner
+    end
+
+    should "have the runs" do
+      assert_includes Dk::HasTheRuns, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner = @runner_class.new
+    end
+    subject{ @runner }
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @params = { Factory.string => Factory.string }
+      @task = @runner.run(TestTask, @params)
+    end
+    subject{ @task }
+
+    should "run the task with any given params and run any sub-tasks" do
+      assert_true subject.run_called
+      assert_equal @params, subject.run_params
+
+      sub_task = subject.sub_task
+      assert_instance_of TestTask::SubTask, sub_task
+      assert_true sub_task.run_called
+      assert_equal subject.sub_task_params, sub_task.run_params
+
+      sub_sub_task = sub_task.sub_task
+      assert_instance_of TestTask::SubSubTask, sub_sub_task
+      assert_true sub_sub_task.run_called
+      assert_equal sub_task.sub_task_params, sub_sub_task.run_params
+    end
+
+    should "capture any sub-tasks that were run" do
+      assert_equal 1, @runner.runs.size
+
+      task_run = @runner.runs.first
+      assert_equal TestTask, task_run.task_class
+      assert_equal @params,  task_run.params
+
+      assert_equal 1, task_run.runs.size
+
+      sub_task_run = task_run.runs.first
+      assert_equal TestTask::SubTask,       sub_task_run.task_class
+      assert_equal subject.sub_task_params, sub_task_run.params
+
+      assert_equal 1, sub_task_run.runs.size
+
+      sub_sub_task_run = sub_task_run.runs.first
+      assert_equal TestTask::SubSubTask,             sub_sub_task_run.task_class
+      assert_equal subject.sub_task.sub_task_params, sub_sub_task_run.params
+    end
+
+  end
+
+  class TestTask
+    include Dk::Task
+
+    attr_reader :run_called, :run_params
+    attr_reader :sub_task_params, :sub_task
+
+    def run!
+      @run_called = true
+      @run_params = params
+
+      @sub_task_params = { Factory.string => Factory.string }
+      @sub_task = run_task(SubTask, @sub_task_params)
+    end
+
+    class SubTask
+      include Dk::Task
+
+      attr_reader :run_called, :run_params
+      attr_reader :sub_task_params, :sub_task
+
+      def run!
+        @run_called = true
+        @run_params = params
+
+        @sub_task_params = { Factory.string => Factory.string }
+        @sub_task = run_task(SubSubTask, @sub_task_params)
+      end
+    end
+
+    class SubSubTask
+      include Dk::Task
+
+      attr_reader :run_called, :run_params
+
+      def run!
+        @run_called = true
+        @run_params = params
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This sets up the 4 different runners Dk will use so that new
features can be added with all runner concerns covered.  This
also breaks out a new `run_task` method on the base Runner that
is used for running sub-tasks (tasks from other tasks).  This is
needed to distinguish whether a task run is for a top level task
or a sub-task b/c the runner's behavior changes depending on this
(for example the test runner doesn't run sub-tasks).

The main DkRunner and the DryRunner simply subclass Runner for now.
THe main DkRunner will be used for running live tasks while the
DryRunner will be used for just logging task activity but not
actually running and task cmds.

The TestRunner will run tasks in tests.  This runner disabled
running sub-tasks but captures anything it runs (tasks or cmds in
the future).

The TreeRunner subclasses DryRunner b/c it too will run all the
sub-tasks with disabled cmds.  However, like the TestRunner, it
captures all sub-tasks run in a tree and will display this tree
in the future.  It will also disable logging in the future.

@jcredding ready for review.
