### PR TITLE
add task test helpers for building test runners and test tasks

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -27,7 +27,11 @@ module Dk
     private
 
     def build_and_run_task(task_class, params = nil)
-      task_class.new(self, params).tap(&:dk_run)
+      build_task(task_class, params).tap(&:dk_run)
+    end
+
+    def build_task(task_class, params = nil)
+      task_class.new(self, params)
     end
 
     def normalize_params(params)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -30,6 +30,10 @@ module Dk
         raise NotImplementedError
       end
 
+      def ==(other_task)
+        self.class == other_task.class
+      end
+
       private
 
       # Helpers
@@ -55,6 +59,30 @@ module Dk
         @description
       end
       alias_method :desc, :description
+
+    end
+
+    module TestHelpers
+      include MuchPlugin
+
+      plugin_included do
+        require 'dk/test_runner'
+        include InstanceMethods
+      end
+
+      module InstanceMethods
+
+        def test_runner(task_class, args = nil)
+          Dk::TestRunner.new(args).tap do |runner|
+            runner.task_class = task_class
+          end
+        end
+
+        def test_task(task_class, args = nil)
+          test_runner(task_class, args).task
+        end
+
+      end
 
     end
 

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -7,6 +7,17 @@ module Dk
   class TestRunner < Runner
     include HasTheRuns
 
+    attr_accessor :task_class
+
+    def task(params = nil)
+      build_task(self.task_class, params)
+    end
+
+    # test runners are designed to only run their task class's tasks
+    def run(params = nil)
+      super(self.task_class, params)
+    end
+
     # don't run any sub-tasks, just track that a sub-task was run
     def run_task(task_class, params = nil)
       self.runs << TaskRun.new(task_class, params)

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -29,8 +29,20 @@ class Dk::TestRunner
     desc "when init"
     setup do
       @runner = @runner_class.new
+      @runner.task_class = TestTask
     end
     subject{ @runner }
+
+    should have_accessors :task_class
+    should have_imeths :task
+
+    should "know how to build a task of its task class" do
+      params = { Factory.string => Factory.string }
+      task = subject.task(params)
+
+      assert_instance_of subject.task_class, task
+      assert_equal params, task.instance_eval{ params }
+    end
 
   end
 
@@ -38,7 +50,7 @@ class Dk::TestRunner
     desc "and run"
     setup do
       @params = { Factory.string => Factory.string }
-      @task = @runner.run(TestTask, @params)
+      @task = @runner.run(@params)
     end
     subject{ @task }
 


### PR DESCRIPTION
These are intended to help developers with building runners and
tasks in tests.  The idea is they shouldn't have to know the
relationship of the runners and tasks to test their tasks.  They
shouldn't be building runners/tasks manually b/c their are things
that need to "line up".

I'm going for a similar api to the test helpers in our "handler
pattern" gems (ie Deas, Sanford and Qs).  That means altering the
signature of the test runner's run method to only take optional
params.  This means you configure a task class on the test runner
and calling run builds a task of that class and runs it.  I also
added a `task` method on the test runner to match the `handler`
method on the handler pattern test runners.

Note: I switched to using the test helpers on the task tests to
further validate they work as intended.  This was done in the
handler pattern gems too.

@jcredding ready for review.  You cool with the mods to the TestRunner?
