### PR TITLE
`halt` task helper method

### DIFF
--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -22,7 +22,7 @@ module Dk
 
       def dk_run
         self.dk_run_callbacks 'before'
-        self.run!
+        catch(:halt){ self.run! }
         self.dk_run_callbacks 'after'
       end
 
@@ -44,6 +44,10 @@ module Dk
 
       # Helpers
 
+      def run_task(task_class, params = nil)
+        @dk_runner.run_task(task_class, params)
+      end
+
       def params
         @dk_params
       end
@@ -52,8 +56,8 @@ module Dk
         @dk_runner.set_param(key, value)
       end
 
-      def run_task(task_class, params = nil)
-        @dk_runner.run_task(task_class, params)
+      def halt
+        throw :halt
       end
 
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -22,7 +22,7 @@ class Dk::Runner
     subject{ @runner }
 
     should have_readers :params
-    should have_imeths :run, :set_param
+    should have_imeths :run, :run_task, :set_param
 
     should "default its attrs" do
       assert_equal({}, subject.params)
@@ -54,14 +54,6 @@ class Dk::Runner
       assert_equal exp, runner.params
     end
 
-    should "stringify and set param values with `set_param`" do
-      key, value = Factory.string.to_sym, Factory.string
-      subject.set_param(key, value)
-
-      assert_equal value, subject.params[key.to_s]
-      assert_raises(ArgumentError){ subject.params[key] }
-    end
-
     should "build and run a given task class" do
       params = { Factory.string => Factory.string }
 
@@ -80,6 +72,14 @@ class Dk::Runner
       task = subject.run_task(TestTask, params)
       assert_true task.run_called
       assert_equal params, task.run_params
+    end
+
+    should "stringify and set param values with `set_param`" do
+      key, value = Factory.string.to_sym, Factory.string
+      subject.set_param(key, value)
+
+      assert_equal value, subject.params[key.to_s]
+      assert_raises(ArgumentError){ subject.params[key] }
     end
 
   end


### PR DESCRIPTION
This method halts execution on _only_ the current task being run.
The goal is to give a helper to say "I'm done with this task" but
keep running through all the other tasks that are supposed to run.

Note: it isn't recommended you use this for error handling or in
error scenarios where you want to stop execution of not only the
current task but any subsequent tasks.  In this scenario, simply
raise an exception.

Note also: this reworks and cleans up some runner related logic
and tests to better match the order of the task helper methods
and to cleanup some things that were missed in previous efforts.

@jcredding ready for review.
