### PR TITLE
log task helper methods

### DIFF
--- a/lib/dk/null_logger.rb
+++ b/lib/dk/null_logger.rb
@@ -1,0 +1,13 @@
+require 'logger'
+
+module Dk
+
+  class NullLogger
+
+    ::Logger::Severity.constants.each do |name|
+      define_method(name.downcase){ |*args| } # no-op
+    end
+
+  end
+
+end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,13 +1,17 @@
+require 'dk/null_logger'
+
 module Dk
 
   class Runner
 
-    attr_reader :params
+    attr_reader :params, :logger
 
     def initialize(args = nil)
       args ||= {}
       @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
       @params.merge!(normalize_params(args[:params]))
+
+      @logger = args[:logger] || NullLogger.new
     end
 
     # called by CLI on top-level tasks
@@ -21,8 +25,12 @@ module Dk
     end
 
     def set_param(key, value)
-      @params.merge!(normalize_params({ key => value }))
+      self.params.merge!(normalize_params({ key => value }))
     end
+
+    def log_info(msg);  self.logger.info(msg);  end
+    def log_debug(msg); self.logger.debug(msg); end
+    def log_error(msg); self.logger.error(msg); end
 
     private
 

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -60,6 +60,10 @@ module Dk
         throw :halt
       end
 
+      def log_info(msg);  @dk_runner.log_info(msg);  end
+      def log_debug(msg); @dk_runner.log_debug(msg); end
+      def log_error(msg); @dk_runner.log_error(msg); end
+
     end
 
     module ClassMethods

--- a/test/unit/null_logger_tests.rb
+++ b/test/unit/null_logger_tests.rb
@@ -1,0 +1,17 @@
+require 'assert'
+require 'dk/null_logger'
+
+class Dk::NullLogger
+
+  class UnitTests < Assert::Context
+    desc "Dk::NullLogger"
+    setup do
+      @null_logger = Dk::NullLogger.new
+    end
+    subject{ @null_logger }
+
+    should have_imeths :info, :debug, :error
+
+  end
+
+end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -236,6 +236,33 @@ module Dk::Task
 
   end
 
+  class LogPrivateHelpersTests < InitTests
+    setup do
+      @runner_log_info_called_with  = nil
+      Assert.stub(@runner, :log_info){ |*args| @runner_log_info_called_with = args }
+
+      @runner_log_debug_called_with = nil
+      Assert.stub(@runner, :log_debug){ |*args| @runner_log_debug_called_with = args }
+
+      @runner_log_error_called_with = nil
+      Assert.stub(@runner, :log_error){ |*args| @runner_log_error_called_with = args }
+    end
+
+    should "log by calling the runner's log methods" do
+      msg = Factory.string
+
+      subject.instance_eval{ log_info(msg) }
+      assert_equal [msg], @runner_log_info_called_with
+
+      subject.instance_eval{ log_debug(msg) }
+      assert_equal [msg], @runner_log_debug_called_with
+
+      subject.instance_eval{ log_error(msg) }
+      assert_equal [msg], @runner_log_error_called_with
+    end
+
+  end
+
   class TestHelpersTests < UnitTests
     desc "TestHelpers"
     setup do


### PR DESCRIPTION
This adds some helper methods to tasks for logging output.  Info
logging is for general task feedback to the user.  Debug logging
is intended for verbose feeback to the user.  Error logging is
for letting the user know an error has occurred.

This logging methods all call to the runner's logger.  This allows
different runners to supply different loggers to alter the logging
behavior based on their design needs.  For now, the base runner
defaults the logger to a null logger that does nothing.

In the future, the test runner and tree runner will continue just
using the default null logger.  These loggers should never show
any output to the user as they are for internal use only (ie you
don't want logs outputting while running a test suite or while
building the task tree for display).

In the future, the live/dry runners will configure a Logsly logger
on stdout. This logger will force the task feedback to stdout while
allowing the user to configure the stdout logger details for style,
etc.  There will also be an option to configure file logging.  The
dry runner will have the same logger as the live logger since it
is designed to imitate live logging as closely as possible.

@jcredding ready for review.
