### PR TITLE
local cmd and spy objects

### DIFF
--- a/dk.gemspec
+++ b/dk.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert", ["~> 2.16.1"])
 
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
+  gem.add_dependency("scmd",        ["~> 3.0.2"])
 
 end

--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -1,0 +1,74 @@
+require 'scmd'
+
+module Dk; end
+module Dk::Local
+
+  class BaseCmd
+
+    def initialize(scmd_or_spy)
+      @scmd = scmd_or_spy
+    end
+
+    def cmd_str; @scmd.cmd_str; end
+
+    def run(input = nil);  @scmd.run(input);  self; end
+    def run!(input = nil); @scmd.run!(input); self; end
+
+    def stdout;   @scmd.stdout;   end
+    def stderr;   @scmd.stderr;   end
+    def success?; @scmd.success?; end
+    def to_s;     @scmd.to_s;     end
+
+    def output_lines
+      build_stdout_lines(self.stdout) + build_stderr_lines(self.stderr)
+    end
+
+    private
+
+    def build_stdout_lines(stdout)
+      build_output_lines('stdout', stdout)
+    end
+
+    def build_stderr_lines(stderr)
+      build_output_lines('stderr', stderr)
+    end
+
+    def build_output_lines(name, output)
+      output.to_s.strip.split("\n").map{ |line| OutputLine.new(name, line) }
+    end
+
+    OutputLine = Struct.new(:name, :line)
+
+  end
+
+  class Cmd < BaseCmd
+
+    def initialize(cmd_str, opts = nil)
+      opts ||= {}
+      super(Scmd.new(cmd_str, :env => opts[:env]))
+    end
+
+  end
+
+  class CmdSpy < BaseCmd
+
+    attr_reader :cmd_opts
+
+    def initialize(cmd_str, opts = nil)
+      require 'scmd/command_spy'
+      super(Scmd::CommandSpy.new(cmd_str, opts))
+      @cmd_opts = opts
+    end
+
+    def stdout=(value);     @scmd.stdout     = value; end
+    def stderr=(value);     @scmd.stderr     = value; end
+    def exitstatus=(value); @scmd.exitstatus = value; end
+
+    def run_calls;        @scmd.run_calls;        end
+    def run_bang_calls;   @scmd.run_bang_calls;   end
+    def run_called?;      @scmd.run_called?;      end
+    def run_bang_called?; @scmd.run_bang_called?; end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,9 @@ require 'pry'
 
 require 'test/support/factory'
 
+# put scmd in test mode
+ENV['SCMD_TEST_MODE'] = '1'
+
 # 1.8.7 backfills
 
 # Array#sample

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,16 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.stdout
+    Factory.integer(3).times.map{ Factory.string }.join("\n")
+  end
+
+  def self.stderr
+    Factory.integer(3).times.map{ Factory.string }.join("\n")
+  end
+
+  def self.exitstatus
+    [0, 1].sample
+  end
+
 end

--- a/test/unit/local_tests.rb
+++ b/test/unit/local_tests.rb
@@ -1,0 +1,148 @@
+require 'assert'
+require 'dk/local'
+
+require 'scmd/command_spy'
+
+module Dk::Local
+
+  class UnitTests < Assert::Context
+    desc "Dk::Local"
+    setup do
+      @cmd_str  = Factory.string
+      @scmd_spy = Scmd::CommandSpy.new(@cmd_str).tap do |spy|
+        spy.exitstatus = Factory.exitstatus
+        spy.stdout     = [Factory.stdout, nil].sample
+        spy.stderr     = [Factory.stderr, nil].sample
+      end
+    end
+    subject{ @cmd }
+
+  end
+
+  class BaseCmdTests < UnitTests
+    desc "BaseCmd"
+    setup do
+      @cmd_class = Dk::Local::BaseCmd
+      @cmd = @cmd_class.new(@scmd_spy)
+    end
+
+    should have_imeths :cmd_str, :run, :run!, :stdout, :stderr, :success?
+    should have_imeths :to_s, :output_lines
+
+    should "demeter its scmd" do
+      assert_equal @scmd_spy.cmd_str, subject.cmd_str
+
+      assert_false @scmd_spy.run_called?
+      subject.run
+      assert_true @scmd_spy.run_called?
+
+      assert_false @scmd_spy.run_bang_called?
+      subject.run!
+      assert_true @scmd_spy.run_bang_called?
+
+      assert_equal @scmd_spy.stdout,   subject.stdout
+      assert_equal @scmd_spy.stderr,   subject.stderr
+      assert_equal @scmd_spy.success?, subject.success?
+      assert_equal @scmd_spy.to_s,     subject.to_s
+    end
+
+    should "know its output lines" do
+      stdout_lines = subject.stdout.to_s.split("\n")
+      stderr_lines = subject.stderr.to_s.split("\n")
+      output_lines = subject.output_lines
+
+      exp = (stdout_lines + stderr_lines).size
+      assert_equal exp, output_lines.size
+
+      if output_lines.size > 0
+        assert_instance_of BaseCmd::OutputLine, output_lines.sample
+      end
+
+      exp = stdout_lines.size.times.map{ 'stdout' } +
+            stderr_lines.size.times.map{ 'stderr' }
+      assert_equal exp, output_lines.map(&:name)
+
+      exp = stdout_lines + stderr_lines
+      assert_equal exp, output_lines.map(&:line)
+    end
+
+  end
+
+  class CmdTests < UnitTests
+    desc "Cmd"
+    setup do
+      @cmd_class = Dk::Local::Cmd
+
+      @scmd_new_called_with = nil
+      Assert.stub(Scmd, :new) do |*args|
+        @scmd_new_called_with = args
+        @scmd_spy
+      end
+
+      @cmd = @cmd_class.new(@cmd_str)
+    end
+
+    should "build an scmd with the cmd str and any given :env option" do
+      assert_equal [@cmd_str, { :env => nil }], @scmd_new_called_with
+
+      opts = {
+        :env           => Factory.string,
+        Factory.string => Factory.string
+      }
+      @cmd_class.new(@cmd_str, opts)
+      assert_equal [@cmd_str, { :env => opts[:env] }], @scmd_new_called_with
+    end
+
+  end
+
+  class CmdSpyTests < UnitTests
+    desc "CmdSpy"
+    setup do
+      @cmd_class = Dk::Local::CmdSpy
+
+      @scmd_spy_new_called_with = nil
+      Assert.stub(Scmd::CommandSpy, :new) do |*args|
+        @scmd_spy_new_called_with = args
+        @scmd_spy
+      end
+
+      @cmd = @cmd_class.new(@cmd_str)
+    end
+
+    should have_readers :cmd_opts
+    should have_imeths :stdout=, :stderr=, :exitstatus=
+    should have_imeths :run_calls, :run_bang_calls
+    should have_imeths :run_called?, :run_bang_called?
+
+    should "build an scmd spy with the cmd str and any given options" do
+      assert_equal [@cmd_str, nil], @scmd_spy_new_called_with
+      assert_nil subject.cmd_opts
+
+      opts = { Factory.string => Factory.string }
+      cmd  = @cmd_class.new(@cmd_str, opts)
+      assert_equal [@cmd_str, opts], @scmd_spy_new_called_with
+      assert_equal opts, cmd.cmd_opts
+    end
+
+    should "demeter its scmd spy" do
+      stdout = Factory.stdout
+      subject.stdout = stdout
+      assert_equal stdout, @scmd_spy.stdout
+
+      stderr = Factory.stderr
+      subject.stderr = stderr
+      assert_equal stderr, @scmd_spy.stderr
+
+      exitstatus = Factory.exitstatus
+      subject.exitstatus = exitstatus
+      assert_equal exitstatus, @scmd_spy.exitstatus
+
+      assert_equal @scmd_spy.run_calls,        subject.run_calls
+      assert_equal @scmd_spy.run_bang_calls,   subject.run_bang_calls
+      assert_equal @scmd_spy.run_called?,      subject.run_called?
+      assert_equal @scmd_spy.run_bang_called?, subject.run_bang_called?
+    end
+
+  end
+
+end


### PR DESCRIPTION
These objects will be used to track and run local commands in
tasks.  In a coming PR, tasks will get an API for running local
cmds in their tasks.  That API will build these objects and run
them.  A spy is added b/c the test runner will only want to
create spies from its API.  Also the test runner will need an
API for users to stub in custom cmd spies to immitate task
behavior in tests.

The local cmd and spy both compose Scmd cmds and spies.  They both
provide a subset of Scmd's API designed for Dk use.  Both also
have the concept of "output lines".  This is the captured output
for the command in a structured format that will be used for
logging cmd output in a standard way.

Note: the coming remote cmd objects will have a similar, limited
API that matches the local cmd.  The main difference will be that
you can access the stdout/stderr of local cmds but will not be
able to in remote cmds.  This is b/c the value could be diffrent
across the number of hosts the remote cmd is run on.

@jcredding ready for review.
