### PR TITLE
rework test runner test task API

### DIFF
--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -9,23 +9,21 @@ module Dk
 
     attr_accessor :task_class
 
-    def task(params = nil)
-      build_task(self.task_class, params)
-    end
-
-    # test runners are designed to only run their task class's tasks
+    # test runners are designed to only run their task
     def run(params = nil)
-      super(self.task_class, params)
+      self.task(params).tap(&:dk_run)
     end
 
     # don't run any sub-tasks, just track that a sub-task was run
     def run_task(task_class, params = nil)
-      self.runs << TaskRun.new(task_class, params)
+      TaskRun.new(task_class, params).tap{ |tr| self.runs << tr }
     end
 
-    # TODO: don't run any cmds, just track that a cmd was run
+    # test task API
 
-    # TODO: disable any logging
+    def task(params = nil)
+      @task ||= build_task(self.task_class, params)
+    end
 
   end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -59,13 +59,17 @@ class Dk::TestRunner
       assert_equal @params, subject.run_params
     end
 
-    should "capture any sub-tasks that were run but not actually run them" do
+    should "capture any sub-tasks that were run" do
       assert_equal 1, @runner.runs.size
 
-      sub_task_run = @runner.runs.first
-      assert_equal TestTask::SubTask,       sub_task_run.task_class
-      assert_equal subject.sub_task_params, sub_task_run.params
-      assert_equal [],                      sub_task_run.runs
+      st = @runner.runs.first
+
+      assert_instance_of Dk::TaskRun, st
+
+      assert_same st, subject.sub_task
+      assert_equal TestTask::SubTask,       st.task_class
+      assert_equal subject.sub_task_params, st.params
+      assert_equal [],                      st.runs
     end
 
   end
@@ -74,14 +78,17 @@ class Dk::TestRunner
     include Dk::Task
 
     attr_reader :run_called, :run_params
-    attr_reader :sub_task_params
+    attr_reader :sub_task
+
+    def sub_task_params
+      @sub_task_params ||= { Factory.string => Factory.string }
+    end
 
     def run!
       @run_called = true
       @run_params = params
 
-      @sub_task_params = { Factory.string => Factory.string }
-      run_task(SubTask, @sub_task_params)
+      @sub_task = run_task(SubTask, self.sub_task_params)
     end
 
     class SubTask


### PR DESCRIPTION
This is prep for adding local cmd handling and stubbing APIs to
the test runner.  These were noticed while planning for local
cmds and how the test runner will interact with them.

First, this forces that the test runner only ever runs its task.
The goal here is that if you get a task instance from a test
runner and the run the test runner, that specific task will be
the task that is run.  This keeps everything in line and
consistent for testing purposes.

Second, this reworks the test runner tests to prep for capturing
local cmd runs.  This makes the getting the test task state
easier and will allow for testing the test runner cmd stubbing
API in a coming PR.

@jcredding ready for review.
