### PR TITLE
add local cmd handling API on tasks and runners

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,3 +1,4 @@
+require 'dk/local'
 require 'dk/null_logger'
 
 module Dk
@@ -28,9 +29,21 @@ module Dk
       self.params.merge!(normalize_params({ key => value }))
     end
 
-    def log_info(msg);  self.logger.info(msg);  end
-    def log_debug(msg); self.logger.debug(msg); end
-    def log_error(msg); self.logger.error(msg); end
+    def log_info(msg);  self.logger.info(msg);  end # TODO: style up
+    def log_debug(msg); self.logger.debug(msg); end # TODO: style up
+    def log_error(msg); self.logger.error(msg); end # TODO: style up
+
+    def cmd(cmd_str, opts)
+      build_and_log_local_cmd(cmd_str, opts) do |cmd|
+        cmd.run
+      end
+    end
+
+    def cmd!(cmd_str, opts)
+      build_and_log_local_cmd(cmd_str, opts) do |cmd|
+        cmd.run!
+      end
+    end
 
     private
 
@@ -40,6 +53,23 @@ module Dk
 
     def build_task(task_class, params = nil)
       task_class.new(self, params)
+    end
+
+    def build_and_log_local_cmd(cmd_str, opts, &block)
+      log_local_cmd(build_local_cmd(cmd_str, opts), &block)
+    end
+
+    def build_local_cmd(cmd_str, opts)
+      Local::Cmd.new(cmd_str, opts)
+    end
+
+    def log_local_cmd(cmd, &block)
+      self.logger.info(cmd.cmd_str) # TODO: style up
+      block.call(cmd)
+      cmd.output_lines.each do |output_line|
+        self.logger.debug(output_line.line) # TODO: style up, include name
+      end
+      cmd
     end
 
     def normalize_params(params)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -48,6 +48,14 @@ module Dk
         @dk_runner.run_task(task_class, params)
       end
 
+      def cmd(cmd_str, opts = nil)
+        @dk_runner.cmd(cmd_str, opts)
+      end
+
+      def cmd!(cmd_str, opts = nil)
+        @dk_runner.cmd!(cmd_str, opts)
+      end
+
       def params
         @dk_params
       end

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -1,4 +1,5 @@
 require 'dk/has_the_runs'
+require 'dk/local'
 require 'dk/runner'
 require 'dk/task_run'
 
@@ -19,10 +20,49 @@ module Dk
       TaskRun.new(task_class, params).tap{ |tr| self.runs << tr }
     end
 
+    # track that a local cmd was run
+    def cmd(cmd_str, opts)
+      super(cmd_str, opts).tap{ |c| self.runs << c }
+    end
+
+    # track that a local cmd was run
+    def cmd!(cmd_str, opts)
+      super(cmd_str, opts).tap{ |c| self.runs << c }
+    end
+
     # test task API
 
     def task(params = nil)
       @task ||= build_task(self.task_class, params)
+    end
+
+    # local cmd stub API
+
+    def stub_cmd(cmd_str, opts = nil, &block)
+      build_local_cmd(cmd_str, opts).tap{ |spy| block.call(spy) }
+    end
+
+    def unstub_cmd(cmd_str, opts = nil)
+      local_cmd_spies.delete(local_cmds_key(cmd_str, opts))
+    end
+
+    def unstub_all_cmds
+      local_cmd_spies.clear
+    end
+
+    private
+
+    # don't run any local cmds, always return spies that act like local cmds
+    def build_local_cmd(cmd_str, opts)
+      local_cmd_spies[local_cmds_key(cmd_str, opts)]
+    end
+
+    def local_cmd_spies
+      @local_cmd_spies ||= Hash.new{ |h, k| h[k] = Local::CmdSpy.new(*k) }
+    end
+
+    def local_cmds_key(cmd_str, opts = nil)
+      [cmd_str, opts]
     end
 
   end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -151,6 +151,35 @@ module Dk::Task
 
   end
 
+  class RunLocalCmdPrivateHelpersTests < InitTests
+    setup do
+      @runner_cmd_called_with = nil
+      Assert.stub(@runner, :cmd){ |*args| @runner_cmd_called_with = args }
+
+      @runner_cmd_bang_called_with = nil
+      Assert.stub(@runner, :cmd!){ |*args| @runner_cmd_bang_called_with = args }
+    end
+
+    should "run local cmds by calling the runner's `cmd` methods" do
+      cmd_str  = Factory.string
+      cmd_opts = { Factory.string => Factory.string }
+      subject.instance_eval{ cmd(cmd_str, cmd_opts) }
+
+      exp = [cmd_str, cmd_opts]
+      assert_equal exp, @runner_cmd_called_with
+    end
+
+    should "run local cmds by calling the runner's `cmd!` methods" do
+      cmd_str  = Factory.string
+      cmd_opts = { Factory.string => Factory.string }
+      subject.instance_eval{ cmd!(cmd_str, cmd_opts) }
+
+      exp = [cmd_str, cmd_opts]
+      assert_equal exp, @runner_cmd_bang_called_with
+    end
+
+  end
+
   class ParamsPrivateHelpersTests < InitTests
     setup do
       @task_params = { Factory.string => Factory.string }

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -35,6 +35,7 @@ class Dk::TestRunner
 
     should have_accessors :task_class
     should have_imeths :task
+    should have_imeths :stub_cmd, :unstub_cmd, :unstub_all_cmds
 
     should "know how to build a task of its task class" do
       params = { Factory.string => Factory.string }
@@ -59,17 +60,78 @@ class Dk::TestRunner
       assert_equal @params, subject.run_params
     end
 
-    should "capture any sub-tasks that were run" do
-      assert_equal 1, @runner.runs.size
+    should "capture any sub-tasks or local cmd spies that were run" do
+      assert_equal 3, @runner.runs.size
 
-      st = @runner.runs.first
+      st, lc, lcb = @runner.runs
 
-      assert_instance_of Dk::TaskRun, st
+      assert_instance_of Dk::TaskRun,       st
+      assert_instance_of Dk::Local::CmdSpy, lc
+      assert_instance_of Dk::Local::CmdSpy, lcb
 
       assert_same st, subject.sub_task
       assert_equal TestTask::SubTask,       st.task_class
       assert_equal subject.sub_task_params, st.params
       assert_equal [],                      st.runs
+
+      assert_same lc, subject.local_cmd
+      assert_equal subject.local_cmd_str,  lc.cmd_str
+      assert_equal subject.local_cmd_opts, lc.cmd_opts
+      assert_true lc.run_called?
+
+      assert_same lcb, subject.local_cmd_bang
+      assert_equal subject.local_cmd_str,  lcb.cmd_str
+      assert_equal subject.local_cmd_opts, lcb.cmd_opts
+      assert_true lcb.run_bang_called?
+    end
+
+  end
+
+  class LocalCmdStubTests < InitTests
+    setup do
+      @task = @runner.task
+
+      cmd_spy = nil
+      stdout  = Factory.stdout
+      @runner.stub_cmd(@task.local_cmd_str, @task.local_cmd_opts) do |spy|
+        spy.stdout = stdout
+        cmd_spy    = spy
+      end
+
+      @cmd_spy = cmd_spy
+      @stdout  = stdout
+    end
+    subject{ @task }
+
+    should "stub custom cmd spies" do
+      @runner.run
+
+      assert_same @cmd_spy, subject.local_cmd
+      assert_same @cmd_spy, subject.local_cmd_bang
+
+      assert_true @cmd_spy.run_called?
+      assert_true @cmd_spy.run_bang_called?
+
+      assert_equal @stdout, subject.local_cmd.stdout
+      assert_equal @stdout, subject.local_cmd_bang.stdout
+    end
+
+    should "unstub specific cmd spies" do
+      @runner.unstub_cmd(@task.local_cmd_str, @task.local_cmd_opts)
+
+      @runner.run
+
+      assert_not_same @cmd_spy, subject.local_cmd
+      assert_not_same @cmd_spy, subject.local_cmd_bang
+    end
+
+    should "unstub all cmd spies" do
+      @runner.unstub_all_cmds
+
+      @runner.run
+
+      assert_not_same @cmd_spy, subject.local_cmd
+      assert_not_same @cmd_spy, subject.local_cmd_bang
     end
 
   end
@@ -79,9 +141,18 @@ class Dk::TestRunner
 
     attr_reader :run_called, :run_params
     attr_reader :sub_task
+    attr_reader :local_cmd, :local_cmd_bang
 
     def sub_task_params
       @sub_task_params ||= { Factory.string => Factory.string }
+    end
+
+    def local_cmd_str
+      @local_cmd_str ||= Factory.string
+    end
+
+    def local_cmd_opts
+      @local_cmd_opts ||= { Factory.string => Factory.string }
     end
 
     def run!
@@ -89,6 +160,9 @@ class Dk::TestRunner
       @run_params = params
 
       @sub_task = run_task(SubTask, self.sub_task_params)
+
+      @local_cmd      = cmd(self.local_cmd_str, self.local_cmd_opts)
+      @local_cmd_bang = cmd!(self.local_cmd_str, self.local_cmd_opts)
     end
 
     class SubTask


### PR DESCRIPTION
This adds the API for running local cmds on tasks.  There are two
methods: `cmd` and `cmd!` for running local cmds.  Both run a
given cmd string - the bang version raises an exception if the
cmd is not successful.  Both return the local cmd output so you
can get data about the cmd (whether it succeeded or not, its
stdout, etc).

This also sets up the handling of local cmds in the runners.  All
local cmds are logged using the runner's logger.  The test runner
always builds cmd spies instead of live cmds so that cmds are
never run in tests.  The test runner also has a cmd stubbing API
for adding in custom cmd behavior and cmd spying to task tests.
Finally, the test runner captures cmd spies that are run in its
`runs`.  Use this to test that a task runs a local command.

@jcredding ready for review.
