### PR TITLE
remote cmd and spy objects

### DIFF
--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -5,6 +5,8 @@ module Dk::Local
 
   class BaseCmd
 
+    attr_reader :scmd
+
     def initialize(scmd_or_spy)
       @scmd = scmd_or_spy
     end

--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -1,0 +1,71 @@
+require 'dk/local'
+
+module Dk; end
+module Dk::Remote
+
+  class BaseCmd
+
+    attr_reader :hosts, :cmd_str, :local_cmds
+
+    def initialize(local_cmd_or_spy_klass, cmd_str, opts)
+      opts   ||= {}
+      @hosts   = (opts[:hosts] || []).sort # TODO: accept ssh opts string
+      @cmd_str = cmd_str
+
+      @local_cmds = @hosts.inject({}) do |cmds, host|
+        # TODO: build host-specific ssh cmd str
+        cmds[host] = local_cmd_or_spy_klass.new(cmd_str, :env => opts[:env])
+        cmds
+      end
+    end
+
+    def to_s; self.cmd_str; end
+
+    def run(input = nil)
+      self.hosts.each{ |host| @local_cmds[host].scmd.start(input) }
+      self.hosts.each{ |host| @local_cmds[host].scmd.wait }
+      self
+    end
+
+    def success?
+      self.hosts.inject(true) do |success, host|
+        success && @local_cmds[host].success?
+      end
+    end
+
+    def output_lines
+      self.hosts.inject([]) do |lines, host|
+        lines + @local_cmds[host].output_lines
+      end
+    end
+
+  end
+
+  class Cmd < BaseCmd
+
+    def initialize(cmd_str, opts = nil)
+      super(Dk::Local::Cmd, cmd_str, opts)
+    end
+
+  end
+
+  class CmdSpy < BaseCmd
+
+    attr_reader :cmd_opts
+
+    def initialize(cmd_str, opts = nil)
+      super(Dk::Local::CmdSpy, cmd_str, opts)
+      @cmd_opts = opts
+      @first_local_cmd_spy = @local_cmds[@hosts.first]
+    end
+
+    # just set the first local cmd exitstatus, this will have an overall effect
+    def exitstatus=(value); @first_local_cmd_spy.exitstatus = value; end
+
+    # just query the firs tlocal cmd - if run for one it was run for all
+    def run_calls;   @first_local_cmd_spy.scmd.start_calls;   end
+    def run_called?; @first_local_cmd_spy.scmd.start_called?; end
+
+  end
+
+end

--- a/test/unit/local_tests.rb
+++ b/test/unit/local_tests.rb
@@ -26,8 +26,13 @@ module Dk::Local
       @cmd = @cmd_class.new(@scmd_spy)
     end
 
+    should have_readers :scmd
     should have_imeths :cmd_str, :run, :run!, :stdout, :stderr, :success?
     should have_imeths :to_s, :output_lines
+
+    should "know its scmd" do
+      assert_equal @scmd_spy, subject.scmd
+    end
 
     should "demeter its scmd" do
       assert_equal @scmd_spy.cmd_str, subject.cmd_str

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -1,0 +1,173 @@
+require 'assert'
+require 'dk/remote'
+
+require 'dk/local'
+
+module Dk::Remote
+
+  class UnitTests < Assert::Context
+    desc "Dk::Remote"
+    setup do
+      @hosts   = Factory.integer(3).times.map{ Factory.string }
+      @cmd_str = Factory.string
+
+      @opts = {
+        :env           => Factory.string,
+        :hosts         => @hosts,
+        Factory.string => Factory.string
+      }
+
+      @local_cmd_new_called_with = nil
+      Assert.stub(Dk::Local::Cmd, :new) do |*args|
+        @local_cmd_new_called_with = args
+        Assert.stub_send(Dk::Local::Cmd, :new, *args)
+      end
+
+      @local_cmd_spy_new_called_with = nil
+      Assert.stub(Dk::Local::CmdSpy, :new) do |*args|
+        @local_cmd_spy_new_called_with = args
+        Assert.stub_send(Dk::Local::CmdSpy, :new, *args).tap do |spy|
+          spy.exitstatus = Factory.exitstatus
+          spy.stdout     = [Factory.stdout, nil].sample
+          spy.stderr     = [Factory.stderr, nil].sample
+        end
+      end
+    end
+    subject{ @cmd }
+
+  end
+
+  class BaseCmdTests < UnitTests
+    desc "BaseCmd"
+    setup do
+      @cmd_class = Dk::Remote::BaseCmd
+      @cmd = @cmd_class.new(Dk::Local::CmdSpy, @cmd_str, @opts)
+    end
+
+    should have_readers :hosts, :cmd_str, :local_cmds
+    should have_imeths :to_s, :run, :success?, :output_lines
+
+    should "know its hosts" do
+      assert_equal @hosts.sort, subject.hosts
+    end
+
+    should "know its cmd str" do
+      assert_equal @cmd_str,        subject.cmd_str
+      assert_equal subject.cmd_str, subject.to_s
+    end
+
+    should "build a local cmd for each of its hosts" do
+      subject.hosts.each do |host|
+        assert_instance_of Dk::Local::CmdSpy, subject.local_cmds[host]
+        assert_equal @cmd_str, subject.local_cmds[host].cmd_str
+      end
+      assert_equal [@cmd_str, { :env => @opts[:env] }], @local_cmd_spy_new_called_with
+
+      cmd = @cmd_class.new(Dk::Local::Cmd, @cmd_str, @opts)
+      cmd.hosts.each do |host|
+        assert_instance_of Dk::Local::Cmd, cmd.local_cmds[host]
+        assert_equal @cmd_str, cmd.local_cmds[host].cmd_str
+      end
+      assert_equal [@cmd_str, { :env => @opts[:env] }], @local_cmd_new_called_with
+    end
+
+    should "start and wait on each of its local cmds' scmd when run" do
+      subject.hosts.each do |host|
+        assert_false subject.local_cmds[host].scmd.start_called?
+        assert_false subject.local_cmds[host].scmd.wait_called?
+      end
+
+      input = Factory.string
+      subject.run(input)
+
+      subject.hosts.each do |host|
+        assert_true subject.local_cmds[host].scmd.start_called?
+        assert_true subject.local_cmds[host].scmd.wait_called?
+        assert_equal input, subject.local_cmds[host].scmd.start_calls.last.input
+      end
+    end
+
+    should "know whether it was successful or not" do
+      subject.hosts.each do |host|
+        Assert.stub(subject.local_cmds[host], :success?){ true }
+      end
+      assert_true subject.success?
+
+      Assert.stub(subject.local_cmds[subject.hosts.sample], :success?){ false }
+      assert_false subject.success?
+    end
+
+    should "know its output lines" do
+      exp = []
+      subject.hosts.each do |host|
+        exp += subject.local_cmds[host].output_lines
+      end
+      assert_equal exp, subject.output_lines
+    end
+
+  end
+
+  class CmdTests < UnitTests
+    desc "Cmd"
+    setup do
+      @cmd_class = Dk::Remote::Cmd
+      @cmd = @cmd_class.new(@cmd_str, :hosts => @hosts)
+    end
+
+    should "build a local cmd for each host with the cmd str, given opts" do
+      subject.hosts.each do |host|
+        assert_instance_of Dk::Local::Cmd, subject.local_cmds[host]
+        assert_equal @cmd_str, subject.local_cmds[host].cmd_str
+      end
+      assert_equal [@cmd_str, { :env => nil }], @local_cmd_new_called_with
+
+      cmd  = @cmd_class.new(@cmd_str, @opts)
+      cmd.hosts.each do |host|
+        assert_instance_of Dk::Local::Cmd, cmd.local_cmds[host]
+        assert_equal @cmd_str, cmd.local_cmds[host].cmd_str
+      end
+      assert_equal [@cmd_str, { :env => @opts[:env] }], @local_cmd_new_called_with
+    end
+
+  end
+
+  class CmdSpyTests < UnitTests
+    desc "CmdSpy"
+    setup do
+      @cmd_class = Dk::Remote::CmdSpy
+      @cmd = @cmd_class.new(@cmd_str, :hosts => @hosts)
+    end
+
+    should have_readers :cmd_opts
+    should have_imeths :exitstatus=, :run_calls, :run_called?
+
+    should "build a local cmd spy for each host with the cmd str, given opts" do
+      subject.hosts.each do |host|
+        assert_instance_of Dk::Local::CmdSpy, subject.local_cmds[host]
+        assert_equal @cmd_str, subject.local_cmds[host].cmd_str
+      end
+      assert_equal [@cmd_str, { :env => nil }], @local_cmd_spy_new_called_with
+
+      cmd  = @cmd_class.new(@cmd_str, @opts)
+      cmd.hosts.each do |host|
+        assert_instance_of Dk::Local::CmdSpy, cmd.local_cmds[host]
+        assert_equal @cmd_str, cmd.local_cmds[host].cmd_str
+      end
+      assert_equal [@cmd_str, { :env => @opts[:env] }], @local_cmd_spy_new_called_with
+    end
+
+    should "demeter its first local cmd spy" do
+      first_local_cmd_spy = subject.local_cmds[subject.hosts.first]
+
+      exitstatus = Factory.exitstatus
+      subject.exitstatus = exitstatus
+      assert_equal exitstatus, first_local_cmd_spy.scmd.exitstatus
+
+      subject.run
+      assert_equal first_local_cmd_spy.scmd.start_calls,   subject.run_calls
+      assert_equal first_local_cmd_spy.scmd.start_called?, subject.run_called?
+    end
+
+  end
+
+end


### PR DESCRIPTION
These objects will be used to track and run remote commands in
tasks. In a coming PR, tasks will get an API for running remote
cmds in their tasks. That API will build these objects and run
them. A spy is added b/c the test runner will only want to
create spies from its API. Also the test runner will need an
API for users to stub in custom cmd spies to immitate cmd
behavior in task tests.

The remote cmd and spy both compose local cmds and spies. A local
cmd/spy is built for each host specified.  Both the cmd and spy
provide a similar API to local cmds/spies, however that API is
applied to the set of local cmds. For example, when run, the cmd
runs all of its local cmds at the same time.  The cmd is only
successful if all of its local cmds are successful.  The cmd's
output lines are the concatenation of all of its local cmd's
output lines.  One difference with local cmds though: you cannot
access the stdout/stderr of remote cmds as this data could be
different across each host.

Note: I chose to expose the local cmd's Scmd as a reader.  This
is so I could access internal Scmd things for remote cmds usage.
Specifically the `start` and `wait` API needed for the run
logic.  I didn't want to demeter this in the local cmd's api
b/c it isn't designed to have this api (this is a demeter 
violation though).  I also figured it might be nice to have
access to the Scmd in your tasks (in rare special cases like
getting the PID or something.

In a coming PR, I'll add in the ssh parts of the cmds to make
them actually "remote".  I'll also add in the runner/task
handling API (similar to the one for local cmds).

Note: the remote base cmd takes a local cmd/spy _class_ and
initializes an instance for each host.  This is different than
the local cmd/spy that taskes an already initialized instance.
In a coming PR, I'm going to rework the local cmds to have
similar handling, if nothing else to be consistent with the
remote cmds.

Note also: the `cmd_str` and `to_s` are different than the
local cmds.  The remote cmd tracks this on its own instead
of demetering the local cmd.  This is b/c there isn't an
obvious choice of which local cmd to demeter and we might
as well track it manually b/c it is trivial and it is more
decoupled from the local cmd.  Also, the local cmd will
have all the "ssh markup" in it which I don't want to
display on remote cmds.  I'm going to update the local cmd
to match and be consistent.

@jcredding ready for review.  Are you cool with how I composed local cmds in this?  I'm going to put up another PR with a bunch of mods to the local cmds that came out of this effort.  Most of that is to keep things consistent and shore-up some things I missed.  Anyway, FYI.
