### PR TITLE
local cmd modifications based on remote cmd needs/work

### DIFF
--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -5,21 +5,24 @@ module Dk::Local
 
   class BaseCmd
 
-    attr_reader :scmd
+    attr_reader :scmd, :cmd_str
 
-    def initialize(scmd_or_spy)
-      @scmd = scmd_or_spy
+    def initialize(scmd_or_spy_klass, cmd_str, opts)
+      opts   ||= {}
+      @scmd    = scmd_or_spy_klass.new(cmd_str, :env => opts[:env])
+      @cmd_str = cmd_str
     end
 
-    def cmd_str; @scmd.cmd_str; end
+    def to_s; self.cmd_str; end
 
-    def run(input = nil);  @scmd.run(input);  self; end
-    def run!(input = nil); @scmd.run!(input); self; end
+    def run(input = nil)
+      @scmd.run(input)
+      self
+    end
 
     def stdout;   @scmd.stdout;   end
     def stderr;   @scmd.stderr;   end
     def success?; @scmd.success?; end
-    def to_s;     @scmd.to_s;     end
 
     def output_lines
       build_stdout_lines(self.stdout) + build_stderr_lines(self.stderr)
@@ -46,8 +49,7 @@ module Dk::Local
   class Cmd < BaseCmd
 
     def initialize(cmd_str, opts = nil)
-      opts ||= {}
-      super(Scmd.new(cmd_str, :env => opts[:env]))
+      super(Scmd, cmd_str, opts)
     end
 
   end
@@ -58,7 +60,7 @@ module Dk::Local
 
     def initialize(cmd_str, opts = nil)
       require 'scmd/command_spy'
-      super(Scmd::CommandSpy.new(cmd_str, opts))
+      super(Scmd::CommandSpy, cmd_str, opts)
       @cmd_opts = opts
     end
 
@@ -66,10 +68,8 @@ module Dk::Local
     def stderr=(value);     @scmd.stderr     = value; end
     def exitstatus=(value); @scmd.exitstatus = value; end
 
-    def run_calls;        @scmd.run_calls;        end
-    def run_bang_calls;   @scmd.run_bang_calls;   end
-    def run_called?;      @scmd.run_called?;      end
-    def run_bang_called?; @scmd.run_bang_called?; end
+    def run_calls;   @scmd.run_calls;   end
+    def run_called?; @scmd.run_called?; end
 
   end
 

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -34,15 +34,7 @@ module Dk
     def log_error(msg); self.logger.error(msg); end # TODO: style up
 
     def cmd(cmd_str, opts)
-      build_and_log_local_cmd(cmd_str, opts) do |cmd|
-        cmd.run
-      end
-    end
-
-    def cmd!(cmd_str, opts)
-      build_and_log_local_cmd(cmd_str, opts) do |cmd|
-        cmd.run!
-      end
+      build_and_run_local_cmd(cmd_str, opts)
     end
 
     private
@@ -55,8 +47,8 @@ module Dk
       task_class.new(self, params)
     end
 
-    def build_and_log_local_cmd(cmd_str, opts, &block)
-      log_local_cmd(build_local_cmd(cmd_str, opts), &block)
+    def build_and_run_local_cmd(cmd_str, opts, &block)
+      log_local_cmd(build_local_cmd(cmd_str, opts)){ |cmd| cmd.run }
     end
 
     def build_local_cmd(cmd_str, opts)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -53,7 +53,11 @@ module Dk
       end
 
       def cmd!(cmd_str, opts = nil)
-        @dk_runner.cmd!(cmd_str, opts)
+        cmd = @dk_runner.cmd(cmd_str, opts)
+        if !cmd.success?
+          raise LocalCmdRunError, "error running: `#{cmd.cmd_str}`", caller
+        end
+        cmd
       end
 
       def params
@@ -73,6 +77,8 @@ module Dk
       def log_error(msg); @dk_runner.log_error(msg); end
 
     end
+
+    LocalCmdRunError = Class.new(RuntimeError)
 
     module ClassMethods
 

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -25,11 +25,6 @@ module Dk
       super(cmd_str, opts).tap{ |c| self.runs << c }
     end
 
-    # track that a local cmd was run
-    def cmd!(cmd_str, opts)
-      super(cmd_str, opts).tap{ |c| self.runs << c }
-    end
-
     # test task API
 
     def task(params = nil)

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -30,7 +30,7 @@ class Dk::Runner
     should have_readers :params, :logger
     should have_imeths :run, :run_task, :set_param
     should have_imeths :log_info, :log_debug, :log_error
-    should have_imeths :cmd, :cmd!
+    should have_imeths :cmd
 
     should "know its attrs" do
       assert_equal @args[:params], subject.params
@@ -145,18 +145,6 @@ class Dk::Runner
 
       assert_not_nil @local_cmd
       assert_true @local_cmd.run_called?
-
-      assert_equal exp_log_output(@local_cmd), @log_out
-    end
-
-    should "build, log and run! local cmds" do
-      @runner.cmd!(@cmd_str, @cmd_opts)
-
-      exp = [@cmd_str, @cmd_opts]
-      assert_equal exp, @local_cmd_new_called_with
-
-      assert_not_nil @local_cmd
-      assert_true @local_cmd.run_bang_called?
 
       assert_equal exp_log_output(@local_cmd), @log_out
     end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -82,7 +82,7 @@ class Dk::TestRunner
       assert_same lcb, subject.local_cmd_bang
       assert_equal subject.local_cmd_str,  lcb.cmd_str
       assert_equal subject.local_cmd_opts, lcb.cmd_opts
-      assert_true lcb.run_bang_called?
+      assert_true lcb.run_called?
     end
 
   end
@@ -110,7 +110,6 @@ class Dk::TestRunner
       assert_same @cmd_spy, subject.local_cmd_bang
 
       assert_true @cmd_spy.run_called?
-      assert_true @cmd_spy.run_bang_called?
 
       assert_equal @stdout, subject.local_cmd.stdout
       assert_equal @stdout, subject.local_cmd_bang.stdout


### PR DESCRIPTION
This is a set of changes to the local cmd objects based on R&D
and implementation work on remote cmds.  There are a couple of
small things here (however, the main goal of this is to keep the
implementations as similar as possible):
- have the base cmd take the local cmd/spy _class_ and create an
  instance.  This has no specific value to local cmds, but remote
  cmds needed this API so I'm updating local cmds to match.
- track the cmd str and to_s manually (instead of demetering from
  the Scmd).  Again, no specific value here, but the remote cmd
  needed this so I want the local to match.  Also, this decouples
  slightly from the Scmd.

Finally, this removes the `run!` method from local cmds.  This
issue is that we were relying on Scmd to error in this case.  This
means the error was previously an Scmd error with a backtrace
buried in the local cmd internals.  A better implementation is to
handle this logic in the task (where the `cmd!` api is actually
needed).  This switches to just implementing/calling `run` on the
local cmd and runner.  For the task's `cmd!` method, the run meth
is called and then if the cmd was not successful, a custom task
exception is raised with the caller of the `cmd!` method as the
backtrace.  This results in better errors for the users.  Also,
this is handy b/c it lines up with the remote cmd api/handling.
See PR 13 for reference.

See #13 for reference.

@jcredding ready for review.
