### PR TITLE
add remote cmd handling API on tasks and runners

### DIFF
--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -59,7 +59,9 @@ module Dk::Remote
       @first_local_cmd_spy = @local_cmds[@hosts.first]
     end
 
-    # just set the first local cmd exitstatus, this will have an overall effect
+    # just set the first local cmd, this will have an overall effect
+    def stdout=(value);     @first_local_cmd_spy.stdout     = value; end
+    def stderr=(value);     @first_local_cmd_spy.stderr     = value; end
     def exitstatus=(value); @first_local_cmd_spy.exitstatus = value; end
 
     # just query the firs tlocal cmd - if run for one it was run for all

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,5 +1,6 @@
 require 'dk/local'
 require 'dk/null_logger'
+require 'dk/remote'
 
 module Dk
 
@@ -37,6 +38,10 @@ module Dk
       build_and_run_local_cmd(cmd_str, opts)
     end
 
+    def ssh(cmd_str, opts)
+      build_and_run_remote_cmd(cmd_str, opts)
+    end
+
     private
 
     def build_and_run_task(task_class, params = nil)
@@ -60,6 +65,23 @@ module Dk
       block.call(cmd)
       cmd.output_lines.each do |output_line|
         self.logger.debug(output_line.line) # TODO: style up, include name
+      end
+      cmd
+    end
+
+    def build_and_run_remote_cmd(cmd_str, opts, &block)
+      log_remote_cmd(build_remote_cmd(cmd_str, opts)){ |cmd| cmd.run }
+    end
+
+    def build_remote_cmd(cmd_str, opts)
+      Remote::Cmd.new(cmd_str, opts)
+    end
+
+    def log_remote_cmd(cmd, &block)
+      self.logger.info(cmd.cmd_str) # TODO: style up
+      block.call(cmd)
+      cmd.output_lines.each do |output_line|
+        self.logger.debug(output_line.line) # TODO: style up, include name, host
       end
       cmd
     end

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -55,7 +55,19 @@ module Dk
       def cmd!(cmd_str, opts = nil)
         cmd = @dk_runner.cmd(cmd_str, opts)
         if !cmd.success?
-          raise LocalCmdRunError, "error running: `#{cmd.cmd_str}`", caller
+          raise CmdRunError, "error running `#{cmd.cmd_str}`", caller
+        end
+        cmd
+      end
+
+      def ssh(cmd_str, opts = nil)
+        @dk_runner.ssh(cmd_str, opts)
+      end
+
+      def ssh!(cmd_str, opts = nil)
+        cmd = @dk_runner.ssh(cmd_str, opts)
+        if !cmd.success?
+          raise SSHRunError, "error running `#{cmd.cmd_str}` over ssh", caller
         end
         cmd
       end
@@ -78,7 +90,8 @@ module Dk
 
     end
 
-    LocalCmdRunError = Class.new(RuntimeError)
+    CmdRunError = Class.new(RuntimeError)
+    SSHRunError = Class.new(RuntimeError)
 
     module ClassMethods
 

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -1,5 +1,6 @@
 require 'dk/has_the_runs'
 require 'dk/local'
+require 'dk/remote'
 require 'dk/runner'
 require 'dk/task_run'
 
@@ -25,38 +26,66 @@ module Dk
       super(cmd_str, opts).tap{ |c| self.runs << c }
     end
 
+    # track that a remote cmd was run
+    def ssh(cmd_str, opts)
+      super(cmd_str, opts).tap{ |c| self.runs << c }
+    end
+
     # test task API
 
     def task(params = nil)
       @task ||= build_task(self.task_class, params)
     end
 
-    # local cmd stub API
+    # cmd stub API
 
     def stub_cmd(cmd_str, opts = nil, &block)
       build_local_cmd(cmd_str, opts).tap{ |spy| block.call(spy) }
     end
 
     def unstub_cmd(cmd_str, opts = nil)
-      local_cmd_spies.delete(local_cmds_key(cmd_str, opts))
+      local_cmd_spies.delete(cmd_spy_key(cmd_str, opts))
     end
 
     def unstub_all_cmds
       local_cmd_spies.clear
     end
 
+    # ssh stub API
+
+    def stub_ssh(cmd_str, opts = nil, &block)
+      build_remote_cmd(cmd_str, opts).tap{ |spy| block.call(spy) }
+    end
+
+    def unstub_ssh(cmd_str, opts = nil)
+      remote_cmd_spies.delete(cmd_spy_key(cmd_str, opts))
+    end
+
+    def unstub_all_ssh
+      remote_cmd_spies.clear
+    end
+
     private
 
     # don't run any local cmds, always return spies that act like local cmds
     def build_local_cmd(cmd_str, opts)
-      local_cmd_spies[local_cmds_key(cmd_str, opts)]
+      local_cmd_spies[cmd_spy_key(cmd_str, opts)]
     end
 
     def local_cmd_spies
       @local_cmd_spies ||= Hash.new{ |h, k| h[k] = Local::CmdSpy.new(*k) }
     end
 
-    def local_cmds_key(cmd_str, opts = nil)
+    # don't run any remote cmds, always return spies that act like remote cmds
+    def build_remote_cmd(cmd_str, opts)
+      remote_cmd_spies[cmd_spy_key(cmd_str, opts)]
+    end
+
+    def remote_cmd_spies
+      @remote_cmd_spies ||= Hash.new{ |h, k| h[k] = Remote::CmdSpy.new(*k) }
+    end
+
+    def cmd_spy_key(cmd_str, opts = nil)
       [cmd_str, opts]
     end
 

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -15,4 +15,8 @@ module Factory
     [0, 1].sample
   end
 
+  def self.hosts
+    Factory.integer(3).times.map{ "#{Factory.string}.example.com" }
+  end
+
 end

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -8,7 +8,7 @@ module Dk::Remote
   class UnitTests < Assert::Context
     desc "Dk::Remote"
     setup do
-      @hosts   = Factory.integer(3).times.map{ Factory.string }
+      @hosts   = Factory.hosts
       @cmd_str = Factory.string
 
       @opts = {
@@ -139,7 +139,8 @@ module Dk::Remote
     end
 
     should have_readers :cmd_opts
-    should have_imeths :exitstatus=, :run_calls, :run_called?
+    should have_imeths :stdout=, :stderr=, :exitstatus=
+    should have_imeths :run_calls, :run_called?
 
     should "build a local cmd spy for each host with the cmd str, given opts" do
       subject.hosts.each do |host|
@@ -158,6 +159,14 @@ module Dk::Remote
 
     should "demeter its first local cmd spy" do
       first_local_cmd_spy = subject.local_cmds[subject.hosts.first]
+
+      stdout = Factory.stdout
+      subject.stdout = stdout
+      assert_equal stdout, first_local_cmd_spy.scmd.stdout
+
+      stderr = Factory.stderr
+      subject.stderr = stderr
+      assert_equal stderr, first_local_cmd_spy.scmd.stderr
 
       exitstatus = Factory.exitstatus
       subject.exitstatus = exitstatus


### PR DESCRIPTION
This adds the API for running remote cmds on tasks.  There are two
methods: `ssh` and `ssh!` for running remote cmds.  Both run a
given cmd string - the bang version raises an exception if the
cmd is not successful.  Both return the remote cmd so you can
access its data (whether it succeeded or not, etc).

This also sets up the handling of remote cmds in the runners.  All
remote cmds are logged using the runner's logger.  The test runner
always builds cmd spies instead of live cmds so that cmds are
never run in tests.  The test runner also has a cmd stubbing API
for adding in custom cmd behavior and cmd spying to task tests.
Finally, the test runner captures cmd spies that are run in its
`runs`.  Use this to test that a task runs a remote command.

Note: I chose to name the task/runner method `ssh` (instead of the
more obvious `remote_cmd`) b/c it has the same number of chars as
`cmd` and because it more clearly communicates what is happening
under the covers.  I still like the "remote cmd" name for the
object b/c it more formally models the _concept_ and is the ying
to the local cmd yang.  However the shorter name plus the explicit
intention revealing nature of the method name in the context of a
task wins out.  The runner is the naming cross-over point: it
shows the calling `ssh` means you are building and running a
remote cmd.

Note also: I chose to add `stdout=` and `stderr=` writers to the
remote cmd spy.  I figure it can't hurt (since the implementation
matches `exitstatus=`) and it allows creating spis that produce
output lines (which is nice for testing).

@jcredding ready for review.
