### PR TITLE
add ssh "markup" to RemoteCmd LocalCmd strings

### DIFF
--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -8,9 +8,10 @@ module Dk::Local
     attr_reader :scmd, :cmd_str
 
     def initialize(scmd_or_spy_klass, cmd_str, opts)
-      opts   ||= {}
-      @scmd    = scmd_or_spy_klass.new(cmd_str, :env => opts[:env])
+      opts ||= {}
+
       @cmd_str = cmd_str
+      @scmd    = scmd_or_spy_klass.new(@cmd_str, :env => opts[:env])
     end
 
     def to_s; self.cmd_str; end


### PR DESCRIPTION
This is needed to actually run the cmds on each host remotely.
This adds a new `:ssh_args` option for specifying custom SSH
cmd args.  It handles escaping the cmds appropriately and running
each cmd in a shell which ensures the full user profile is loaded.

Note: this updates the LocalCmd initializer but this has no effect
on the behavior.  The update is just to better match the new
RemoteCmd initializer.

@jcredding ready for review.  I pulled the ssh "markup" from a custom deploy script we wrote for a CLI helper lib that we used on our apps.  You cool with it?
