### PR TITLE
switch RemoteCmd to use custom OutputLine that includes host info

### DIFF
--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -39,7 +39,7 @@ module Dk::Remote
 
     def output_lines
       self.hosts.inject([]) do |lines, host|
-        lines + @local_cmds[host].output_lines
+        lines + build_output_lines(host, @local_cmds[host].output_lines)
       end
     end
 
@@ -50,6 +50,12 @@ module Dk::Remote
       val = "\"#{cmd_str.gsub(/\s+/, ' ')}\"".gsub("\\", "\\\\\\").gsub('"', '\"')
       "ssh #{args} #{host} -- \"sh -c #{val}\""
     end
+
+    def build_output_lines(host, local_cmd_output_lines)
+      local_cmd_output_lines.map{ |ol| OutputLine.new(host, ol.name, ol.line) }
+    end
+
+    OutputLine = Struct.new(:host, :name, :line)
 
   end
 

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -119,9 +119,21 @@ module Dk::Remote
     should "know its output lines" do
       exp = []
       subject.hosts.each do |host|
-        exp += subject.local_cmds[host].output_lines
+        subject.local_cmds[host].output_lines.each do |ol|
+          exp << [host, ol]
+        end
       end
-      assert_equal exp, subject.output_lines
+      output_lines = subject.output_lines
+
+      assert_equal exp.size, output_lines.size
+
+      if output_lines.size > 0
+        assert_instance_of BaseCmd::OutputLine, output_lines.sample
+      end
+
+      assert_equal exp.map{ |(h, ol)| h },       output_lines.map(&:host)
+      assert_equal exp.map{ |(h, ol)| ol.name }, output_lines.map(&:name)
+      assert_equal exp.map{ |(h, ol)| ol.line }, output_lines.map(&:line)
     end
 
   end


### PR DESCRIPTION
The goal here is to be able to log the host that produces each
output line when logging debug info on RemoteCmds.  This switches
from using the local cmd output lines directly to instead building
remote cmd output lines that include host information.

@jcredding ready for review.
