### PR TITLE
add Config class; use to configure/initialize Dk

### DIFF
--- a/lib/dk.rb
+++ b/lib/dk.rb
@@ -1,5 +1,19 @@
-require "dk/version"
+require 'dk/version'
+require 'dk/config'
 require 'dk/task'
 
 module Dk
+
+  def self.config
+    @config ||= Config.new
+  end
+
+  def self.configure(&block)
+    self.config.init_procs << block
+  end
+
+  def self.init
+    self.config.init
+  end
+
 end

--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -1,0 +1,17 @@
+module Dk
+
+  class Config
+
+    attr_reader :init_procs
+
+    def initialize
+      @init_procs = []
+    end
+
+    def init
+      self.init_procs.each{ |block| self.instance_eval(&block) }
+    end
+
+  end
+
+end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,0 +1,39 @@
+require 'assert'
+require 'dk/config'
+
+class Dk::Config
+
+  class UnitTests < Assert::Context
+    desc "Dk::Config"
+    setup do
+      @config_class = Dk::Config
+    end
+    subject{ @config_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @config = @config_class.new
+    end
+    subject{ @config }
+
+    should have_readers :init_procs
+    should have_imeths :init
+
+    should "have no init procs by default" do
+      assert_equal [], subject.init_procs
+    end
+
+    should "instance eval its init procs on init" do
+      init_self = nil
+      subject.init_procs << proc{ init_self = self }
+
+      subject.init
+      assert_equal @config, init_self
+    end
+
+  end
+
+end

--- a/test/unit/dk_tests.rb
+++ b/test/unit/dk_tests.rb
@@ -1,0 +1,40 @@
+require 'assert'
+require 'dk'
+
+require 'dk/config'
+
+module Dk
+
+  class UnitTests < Assert::Context
+    desc "Dk"
+    setup do
+      @dk_module = Dk
+    end
+    subject{ @dk_module }
+
+    should have_imeths :config, :configure, :init
+
+    should "know its config" do
+      assert_instance_of Config, subject.config
+    end
+
+    should "add init procs to its config on `configure`" do
+      assert_equal [], subject.config.init_procs
+
+      init_block = proc{}
+      subject.configure(&init_block)
+
+      assert_equal [init_block], subject.config.init_procs
+    end
+
+    should "instance eval its init procs on init" do
+      config_init_called = false
+      Assert.stub(subject.config, :init){ config_init_called = true }
+
+      subject.init
+      assert_true config_init_called
+    end
+
+  end
+
+end


### PR DESCRIPTION
This sets up how you configure Dk for a task run.  This creates
the Config class that will store the task run configuration.  Dk
has a config class intance.  Call `configure` to add init procs
to the config.  Call `init` to instance eval those inti procs
against the config instance.

This is part of setting up the DSLs and APIs for configuring a Dk
task run.  In future efforts, the CLI will eval a config file
where the user can define init procs.  In addition, 3rd-party
tools can add config init procs when required/mixed in.

@jcredding ready for review.
