### PR TITLE
default the Remote::CmdSpy hosts if none are given

### DIFF
--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -69,10 +69,16 @@ module Dk::Remote
 
   class CmdSpy < BaseCmd
 
+    DEFAULT_HOST_NAME = 'dk-default-cmd-spy-host'.freeze
+
     attr_reader :cmd_opts
 
     def initialize(cmd_str, opts = nil)
-      super(Dk::Local::CmdSpy, cmd_str, opts)
+      opts ||= {}
+      hosts = opts[:hosts] || []
+      hosts << DEFAULT_HOST_NAME if hosts.empty?
+      super(Dk::Local::CmdSpy, cmd_str, opts.merge(:hosts => hosts))
+
       @cmd_opts = opts
       @first_local_cmd_spy = @local_cmds[@hosts.first]
     end

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -179,6 +179,15 @@ module Dk::Remote
     should have_imeths :stdout=, :stderr=, :exitstatus=
     should have_imeths :run_calls, :run_called?
 
+    should "know its default host name" do
+      assert_equal 'dk-default-cmd-spy-host', @cmd_class::DEFAULT_HOST_NAME
+    end
+
+    should "manually define a single host if none are given" do
+      cmd = @cmd_class.new(@cmd_str)
+      assert_equal [@cmd_class::DEFAULT_HOST_NAME], cmd.hosts
+    end
+
     should "build a local cmd spy for each host with the cmd str, given opts" do
       subject.hosts.each do |host|
         assert_instance_of Dk::Local::CmdSpy, subject.local_cmds[host]


### PR DESCRIPTION
This is needed b/c if there are no hosts specified, the spy
methods will fail as they assume a `@first_local_cmd_spy` and
that is `nil` if there are no hosts.

This scenario will come up on ssh cmds that don't specify a custom
`:hosts` value at cmd-time (ie they use the ssh hosts configured
for the task).  This should have been accounted for back in PR 15
but was missed.

See #15 for reference.

@jcredding ready for review.
