### PR TITLE
add a ConfigRunner and have the dk/dry runners subclass it

### DIFF
--- a/lib/dk/config_runner.rb
+++ b/lib/dk/config_runner.rb
@@ -1,0 +1,13 @@
+require 'dk/runner'
+
+module Dk
+
+  class ConfigRunner < Runner
+
+    def initialize(config)
+      super({}) # TODO: set runner args based on the config
+    end
+
+  end
+
+end

--- a/lib/dk/dk_runner.rb
+++ b/lib/dk/dk_runner.rb
@@ -1,8 +1,8 @@
-require 'dk/runner'
+require 'dk/config_runner'
 
 module Dk
 
-  class DkRunner < Runner
+  class DkRunner < ConfigRunner
   end
 
 end

--- a/lib/dk/dry_runner.rb
+++ b/lib/dk/dry_runner.rb
@@ -1,8 +1,8 @@
-require 'dk/runner'
+require 'dk/config_runner'
 
 module Dk
 
-  class DryRunner < Runner
+  class DryRunner < ConfigRunner
 
     # TODO: disable any cmds, just log actions, but run all sub-tasks
 

--- a/test/unit/config_runner_tests.rb
+++ b/test/unit/config_runner_tests.rb
@@ -1,0 +1,33 @@
+require 'assert'
+require 'dk/config_runner'
+
+require 'dk/config'
+require 'dk/runner'
+
+class Dk::ConfigRunner
+
+  class UnitTests < Assert::Context
+    desc "Dk::ConfigRunner"
+    setup do
+      @runner_class = Dk::ConfigRunner
+    end
+    subject{ @runner_class }
+
+    should "be a Dk::Runner" do
+      assert_true subject < Dk::Runner
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @config = Dk::Config.new
+      @runner = @runner_class.new(@config)
+    end
+
+    # TODO: test that the runner gets set with config values
+
+  end
+
+end

--- a/test/unit/dk_runner_tests.rb
+++ b/test/unit/dk_runner_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'dk/dk_runner'
 
-require 'dk/runner'
+require 'dk/config_runner'
 
 class Dk::DkRunner
 
@@ -12,8 +12,8 @@ class Dk::DkRunner
     end
     subject{ @runner_class }
 
-    should "be a Dk::Runner" do
-      assert_true subject < Dk::Runner
+    should "be a Dk::ConfigRunner" do
+      assert_true subject < Dk::ConfigRunner
     end
 
   end

--- a/test/unit/dry_runner_tests.rb
+++ b/test/unit/dry_runner_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'dk/dry_runner'
 
-require 'dk/runner'
+require 'dk/config_runner'
 
 class Dk::DryRunner
 
@@ -12,8 +12,8 @@ class Dk::DryRunner
     end
     subject{ @runner_class }
 
-    should "be a Dk::Runner" do
-      assert_true subject < Dk::Runner
+    should "be a Dk::ConfigRunner" do
+      assert_true subject < Dk::ConfigRunner
     end
 
   end

--- a/test/unit/tree_runner_tests.rb
+++ b/test/unit/tree_runner_tests.rb
@@ -1,8 +1,9 @@
 require 'assert'
 require 'dk/tree_runner'
 
-require 'dk/has_the_runs'
+require 'dk/config'
 require 'dk/dry_runner'
+require 'dk/has_the_runs'
 require 'dk/task'
 require 'dk/task_run'
 
@@ -28,7 +29,8 @@ class Dk::TreeRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @runner = @runner_class.new
+      config = Dk::Config.new
+      @runner = @runner_class.new(config)
     end
     subject{ @runner }
 


### PR DESCRIPTION
The idea is that these runners (including the TreeRunner as it
subclasses the DryRunner) need to set their runner args from a
given configuration's attrs.  This will allow the user to config
settings for Dk runs and have those settings be honored.

Note: the reason this does not apply to the test runner is that
its logic is run in isolation:
- any expected config param values should be manually specified
  when building the test runner
- no callback config settings are needed as callbacks are ignored
- no ssh config settings are needed as all ssh stuff is spied
- no log config settings are needed since there is no logging
- no task config settings are needed since you are testing an
  individual task

All the Config settings should be unit tested separately using
Dk's config and requiring in the config file like the CLI would.

In future efforts, I'll add the relevant config settings and
have the runners pull them from the config as needed.

@jcredding ready for review.
