### PR TITLE
add `set_param` config method and use config params in config runners

### DIFF
--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -1,15 +1,28 @@
+require 'dk/stringify_params'
+
 module Dk
 
   class Config
 
-    attr_reader :init_procs
+    attr_reader :init_procs, :params
 
     def initialize
       @init_procs = []
+      @params     = {}
     end
 
     def init
       self.init_procs.each{ |block| self.instance_eval(&block) }
+    end
+
+    def set_param(key, value)
+      self.params.merge!(dk_normalize_params(key => value))
+    end
+
+    private
+
+    def dk_normalize_params(params)
+      StringifyParams.new(params)
     end
 
   end

--- a/lib/dk/config_runner.rb
+++ b/lib/dk/config_runner.rb
@@ -5,7 +5,9 @@ module Dk
   class ConfigRunner < Runner
 
     def initialize(config)
-      super({}) # TODO: set runner args based on the config
+      super({
+        :params => config.params
+      })
     end
 
   end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,6 +1,7 @@
 require 'dk/local'
 require 'dk/null_logger'
 require 'dk/remote'
+require 'dk/stringify_params'
 
 module Dk
 
@@ -27,7 +28,7 @@ module Dk
     end
 
     def set_param(key, value)
-      self.params.merge!(normalize_params({ key => value }))
+      self.params.merge!(normalize_params(key => value))
     end
 
     def log_info(msg);  self.logger.info(msg);  end # TODO: style up
@@ -88,19 +89,6 @@ module Dk
 
     def normalize_params(params)
       StringifyParams.new(params || {})
-    end
-
-    module StringifyParams
-      def self.new(object)
-        case(object)
-        when ::Hash
-          object.inject({}){ |h, (k, v)| h.merge(k.to_s => self.new(v)) }
-        when ::Array
-          object.map{ |item| self.new(item) }
-        else
-          object
-        end
-      end
     end
 
   end

--- a/lib/dk/stringify_params.rb
+++ b/lib/dk/stringify_params.rb
@@ -1,0 +1,18 @@
+module Dk
+
+  module StringifyParams
+
+    def self.new(object)
+      case(object)
+      when ::Hash
+        object.inject({}){ |h, (k, v)| h.merge(k.to_s => self.new(v)) }
+      when ::Array
+        object.map{ |item| self.new(item) }
+      else
+        object
+      end
+    end
+
+  end
+
+end

--- a/test/unit/config_runner_tests.rb
+++ b/test/unit/config_runner_tests.rb
@@ -25,8 +25,11 @@ class Dk::ConfigRunner
       @config = Dk::Config.new
       @runner = @runner_class.new(@config)
     end
+    subject{ @runner }
 
-    # TODO: test that the runner gets set with config values
+    should "initialize using the config's values" do
+      assert_equal @config.params, subject.params
+    end
 
   end
 

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -19,11 +19,14 @@ class Dk::Config
     end
     subject{ @config }
 
-    should have_readers :init_procs
-    should have_imeths :init
+    should have_readers :init_procs, :params
+    should have_imeths :init, :set_param
 
-    should "have no init procs by default" do
+    should "default its attrs" do
       assert_equal [], subject.init_procs
+
+      exp = {}
+      assert_equal exp, subject.params
     end
 
     should "instance eval its init procs on init" do
@@ -32,6 +35,14 @@ class Dk::Config
 
       subject.init
       assert_equal @config, init_self
+    end
+
+    should "stringify and set param values with `set_param`" do
+      key, value = Factory.string.to_sym, Factory.string
+      subject.set_param(key, value)
+
+      assert_equal value, subject.params[key.to_s]
+      assert_nil subject.params[key]
     end
 
   end


### PR DESCRIPTION
This allows the user to configure a set of global, default param
values that will be available to all tasks being run.  The params
are normalized in the same manner the runner does to help prevent
any param name conflicts when they get applied on the runner.

This is part of setting up the config's API/DSL.

@jcredding ready for review.
