### PR TITLE
add a task callback API to the Config

### DIFF
--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -16,6 +16,26 @@ module Dk
       self.init_procs.each{ |block| self.instance_eval(&block) }
     end
 
+    def set_param(key, value)
+      self.params.merge!(dk_normalize_params(key => value))
+    end
+
+    def before(subject_task_class, callback_task_class, params = nil)
+      subject_task_class.before(callback_task_class, params)
+    end
+
+    def after(subject_task_class, callback_task_class, params = nil)
+      subject_task_class.after(callback_task_class, params)
+    end
+
+    def prepend_before(subject_task_class, callback_task_class, params = nil)
+      subject_task_class.prepend_before(callback_task_class, params)
+    end
+
+    def prepend_after(subject_task_class, callback_task_class, params = nil)
+      subject_task_class.prepend_after(callback_task_class, params)
+    end
+
   end
 
 end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'dk/config'
 
 require 'dk/has_set_param'
+require 'dk/task'
 
 class Dk::Config
 
@@ -27,6 +28,7 @@ class Dk::Config
 
     should have_readers :init_procs, :params
     should have_imeths :init
+    should have_imeths :before, :after, :prepend_before, :prepend_after
 
     should "default its attrs" do
       assert_equal [], subject.init_procs
@@ -41,6 +43,38 @@ class Dk::Config
 
       subject.init
       assert_equal @config, init_self
+    end
+
+    should "append callback tasks to other tasks" do
+      subj_task_class = Class.new{ include Dk::Task }
+      cb_task_class   = Factory.string
+      cb_params       = Factory.string
+
+      subj_task_class.before_callbacks << Factory.string
+      subject.before(subj_task_class, cb_task_class, cb_params)
+      assert_equal cb_task_class, subj_task_class.before_callbacks.last.task_class
+      assert_equal cb_params,     subj_task_class.before_callbacks.last.params
+
+      subj_task_class.after_callbacks << Factory.string
+      subject.after(subj_task_class, cb_task_class, cb_params)
+      assert_equal cb_task_class, subj_task_class.after_callbacks.last.task_class
+      assert_equal cb_params,     subj_task_class.after_callbacks.last.params
+    end
+
+    should "prepend callback tasks to other tasks" do
+      subj_task_class = Class.new{ include Dk::Task }
+      cb_task_class   = Factory.string
+      cb_params       = Factory.string
+
+      subj_task_class.before_callbacks << Factory.string
+      subject.prepend_before(subj_task_class, cb_task_class, cb_params)
+      assert_equal cb_task_class, subj_task_class.before_callbacks.first.task_class
+      assert_equal cb_params,     subj_task_class.before_callbacks.first.params
+
+      subj_task_class.after_callbacks << Factory.string
+      subject.prepend_after(subj_task_class, cb_task_class, cb_params)
+      assert_equal cb_task_class, subj_task_class.after_callbacks.first.task_class
+      assert_equal cb_params,     subj_task_class.after_callbacks.first.params
     end
 
   end


### PR DESCRIPTION
This are just helper methods for setting the callbacks on the
subject task classes directly.  The one advantage is it reads
more like a DSL and the execution can be delayed by running in
a `configure` proc.  This allows you to configure callbacks
at the top of the callback task's file for readability and
reference the callback task before the constant has been
defined:

``` ruby
require 'dk'
require 'my_task'

Dk.configure do
  before MyTask, MyOtherTask, :some => 'param'
end

class MyOtherTask
  include Dk::Task

end
```

Otherwise this is just a thin helper method and you can use it
or not.

@jcredding ready for review.
