### PR TITLE
add ssh dsl methods to the Config

### DIFF
--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -10,6 +10,8 @@ module Dk
     def initialize
       @init_procs = []
       @params     = {}
+      @ssh_hosts  = {}
+      @ssh_args   = ""
     end
 
     def init
@@ -34,6 +36,17 @@ module Dk
 
     def prepend_after(subject_task_class, callback_task_class, params = nil)
       subject_task_class.prepend_after(callback_task_class, params)
+    end
+
+    def ssh_hosts(group_name = nil, value = nil)
+      return @ssh_hosts if group_name.nil?
+      @ssh_hosts[group_name.to_s] = value if !value.nil?
+      @ssh_hosts[group_name.to_s]
+    end
+
+    def ssh_args(value = nil)
+      @ssh_args = value if !value.nil?
+      @ssh_args
     end
 
   end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -29,6 +29,7 @@ class Dk::Config
     should have_readers :init_procs, :params
     should have_imeths :init
     should have_imeths :before, :after, :prepend_before, :prepend_after
+    should have_imeths :ssh_hosts, :ssh_args
 
     should "default its attrs" do
       assert_equal [], subject.init_procs
@@ -75,6 +76,28 @@ class Dk::Config
       subject.prepend_after(subj_task_class, cb_task_class, cb_params)
       assert_equal cb_task_class, subj_task_class.after_callbacks.first.task_class
       assert_equal cb_params,     subj_task_class.after_callbacks.first.params
+    end
+
+    should "know its ssh hosts" do
+      group_name = Factory.string
+      hosts      = Factory.hosts
+
+      assert_equal Hash.new, subject.ssh_hosts
+      assert_nil subject.ssh_hosts(group_name)
+
+      assert_equal hosts, subject.ssh_hosts(group_name, hosts)
+      assert_equal hosts, subject.ssh_hosts(group_name)
+
+      exp = { group_name => hosts }
+      assert_equal exp, subject.ssh_hosts
+    end
+
+    should "know its ssh args" do
+      args = Factory.string
+
+      assert_equal "",   subject.ssh_args
+      assert_equal args, subject.ssh_args(args)
+      assert_equal args, subject.ssh_args
     end
 
   end


### PR DESCRIPTION
This allows the user to configure named ssh host groups to use
when configuring ssh hosts for tasks.  This also allows the user
to configure global default ssh args to use in ssh cmds in tasks.

In a future effort, I'll update the tasks ssh usage to honor these
settings.

@jcredding ready for review.
