### PR TITLE
have Runner use Config's ssh opts; have Task fall back to Runner ssh opts

### DIFF
--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -1,17 +1,24 @@
 require 'dk/has_set_param'
+require 'dk/has_ssh_opts'
 
 module Dk
 
   class Config
     include Dk::HasSetParam
+    include Dk::HasSSHOpts
+
+    DEFAULT_INIT_PROCS = [].freeze
+    DEFAULT_PARAMS     = {}.freeze
+    DEFAULT_SSH_HOSTS  = {}.freeze
+    DEFAULT_SSH_ARGS   = ''.freeze
 
     attr_reader :init_procs, :params
 
     def initialize
-      @init_procs = []
-      @params     = {}
-      @ssh_hosts  = {}
-      @ssh_args   = ""
+      @init_procs = DEFAULT_INIT_PROCS.dup
+      @params     = DEFAULT_PARAMS.dup
+      @ssh_hosts  = DEFAULT_SSH_HOSTS.dup
+      @ssh_args   = DEFAULT_SSH_ARGS.dup
     end
 
     def init
@@ -36,17 +43,6 @@ module Dk
 
     def prepend_after(subject_task_class, callback_task_class, params = nil)
       subject_task_class.prepend_after(callback_task_class, params)
-    end
-
-    def ssh_hosts(group_name = nil, value = nil)
-      return @ssh_hosts if group_name.nil?
-      @ssh_hosts[group_name.to_s] = value if !value.nil?
-      @ssh_hosts[group_name.to_s]
-    end
-
-    def ssh_args(value = nil)
-      @ssh_args = value if !value.nil?
-      @ssh_args
     end
 
   end

--- a/lib/dk/config_runner.rb
+++ b/lib/dk/config_runner.rb
@@ -6,7 +6,9 @@ module Dk
 
     def initialize(config)
       super({
-        :params => config.params
+        :params    => config.params,
+        :ssh_hosts => config.ssh_hosts,
+        :ssh_args  => config.ssh_args
       })
     end
 

--- a/lib/dk/has_ssh_opts.rb
+++ b/lib/dk/has_ssh_opts.rb
@@ -1,0 +1,30 @@
+require 'much-plugin'
+
+module Dk
+
+  module HasSSHOpts
+    include MuchPlugin
+
+    plugin_included do
+      include InstanceMethods
+
+    end
+
+    module InstanceMethods
+
+      def ssh_hosts(group_name = nil, value = nil)
+        return @ssh_hosts if group_name.nil?
+        @ssh_hosts[group_name.to_s] = value if !value.nil?
+        @ssh_hosts[group_name.to_s]
+      end
+
+      def ssh_args(value = nil)
+        @ssh_args = value if !value.nil?
+        @ssh_args
+      end
+
+    end
+
+  end
+
+end

--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -9,8 +9,11 @@ module Dk::Remote
 
     def initialize(local_cmd_or_spy_klass, cmd_str, opts)
       opts ||= {}
+      if (h = opts[:hosts]).nil? || !h.respond_to?(:empty?) || h.empty?
+        raise NoHostsError, "no hosts to run cmd on (#{h.inspect})"
+      end
 
-      @hosts    = (opts[:hosts] || []).sort
+      @hosts    = h.sort
       @ssh_args = opts[:ssh_args] || ''
       @cmd_str  = cmd_str
 
@@ -58,6 +61,8 @@ module Dk::Remote
     OutputLine = Struct.new(:host, :name, :line)
 
   end
+
+  NoHostsError = Class.new(ArgumentError)
 
   class Cmd < BaseCmd
 

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,4 +1,6 @@
+require 'dk/config'
 require 'dk/has_set_param'
+require 'dk/has_ssh_opts'
 require 'dk/local'
 require 'dk/null_logger'
 require 'dk/remote'
@@ -7,15 +9,19 @@ module Dk
 
   class Runner
     include Dk::HasSetParam
+    include Dk::HasSSHOpts
 
     attr_reader :params, :logger
 
-    def initialize(args = nil)
-      args ||= {}
+    def initialize(opts = nil)
+      opts ||= {}
       @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
-      @params.merge!(dk_normalize_params(args[:params]))
+      @params.merge!(dk_normalize_params(opts[:params]))
 
-      @logger = args[:logger] || NullLogger.new
+      @ssh_hosts = opts[:ssh_hosts] || Config::DEFAULT_SSH_HOSTS.dup
+      @ssh_args  = opts[:ssh_args]  || Config::DEFAULT_SSH_ARGS.dup
+
+      @logger = opts[:logger] || NullLogger.new
     end
 
     # called by CLI on top-level tasks

--- a/test/unit/config_runner_tests.rb
+++ b/test/unit/config_runner_tests.rb
@@ -28,7 +28,9 @@ class Dk::ConfigRunner
     subject{ @runner }
 
     should "initialize using the config's values" do
-      assert_equal @config.params, subject.params
+      assert_equal @config.params,    subject.params
+      assert_equal @config.ssh_hosts, subject.ssh_hosts
+      assert_equal @config.ssh_args,  subject.ssh_args
     end
 
   end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'dk/config'
 
 require 'dk/has_set_param'
+require 'dk/has_ssh_opts'
 require 'dk/task'
 
 class Dk::Config
@@ -17,6 +18,17 @@ class Dk::Config
       assert_includes Dk::HasSetParam, subject
     end
 
+    should "include HasSSHOpts" do
+      assert_includes Dk::HasSSHOpts, subject
+    end
+
+    should "know its defaults" do
+      assert_equal Array.new, subject::DEFAULT_INIT_PROCS
+      assert_equal Hash.new,  subject::DEFAULT_PARAMS
+      assert_equal Hash.new,  subject::DEFAULT_SSH_HOSTS
+      assert_equal '',        subject::DEFAULT_SSH_ARGS
+    end
+
   end
 
   class InitTests < UnitTests
@@ -29,13 +41,12 @@ class Dk::Config
     should have_readers :init_procs, :params
     should have_imeths :init
     should have_imeths :before, :after, :prepend_before, :prepend_after
-    should have_imeths :ssh_hosts, :ssh_args
 
     should "default its attrs" do
-      assert_equal [], subject.init_procs
-
-      exp = {}
-      assert_equal exp, subject.params
+      assert_equal @config_class::DEFAULT_INIT_PROCS, subject.init_procs
+      assert_equal @config_class::DEFAULT_PARAMS,     subject.params
+      assert_equal @config_class::DEFAULT_SSH_HOSTS,  subject.ssh_hosts
+      assert_equal @config_class::DEFAULT_SSH_ARGS,   subject.ssh_args
     end
 
     should "instance eval its init procs on init" do
@@ -76,28 +87,6 @@ class Dk::Config
       subject.prepend_after(subj_task_class, cb_task_class, cb_params)
       assert_equal cb_task_class, subj_task_class.after_callbacks.first.task_class
       assert_equal cb_params,     subj_task_class.after_callbacks.first.params
-    end
-
-    should "know its ssh hosts" do
-      group_name = Factory.string
-      hosts      = Factory.hosts
-
-      assert_equal Hash.new, subject.ssh_hosts
-      assert_nil subject.ssh_hosts(group_name)
-
-      assert_equal hosts, subject.ssh_hosts(group_name, hosts)
-      assert_equal hosts, subject.ssh_hosts(group_name)
-
-      exp = { group_name => hosts }
-      assert_equal exp, subject.ssh_hosts
-    end
-
-    should "know its ssh args" do
-      args = Factory.string
-
-      assert_equal "",   subject.ssh_args
-      assert_equal args, subject.ssh_args(args)
-      assert_equal args, subject.ssh_args
     end
 
   end

--- a/test/unit/has_ssh_opts_tests.rb
+++ b/test/unit/has_ssh_opts_tests.rb
@@ -1,0 +1,62 @@
+require 'assert'
+require 'dk/has_ssh_opts'
+
+require 'much-plugin'
+
+module Dk::HasSSHOpts
+
+  class UnitTests < Assert::Context
+    desc "Dk::HasSSHOpts"
+    setup do
+      @mixin_class = Dk::HasSSHOpts
+
+      @opts_class = Class.new do
+        include Dk::HasSSHOpts
+        def initialize
+          @ssh_hosts = {}
+          @ssh_args  = ''
+        end
+      end
+    end
+    subject{ @opts_class }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @opts = @opts_class.new
+    end
+    subject{ @opts }
+
+    should have_imeths :ssh_hosts, :ssh_args
+
+    should "know its ssh hosts" do
+      group_name = Factory.string
+      hosts      = Factory.hosts
+
+      assert_equal Hash.new, subject.ssh_hosts
+      assert_nil subject.ssh_hosts(group_name)
+
+      assert_equal hosts, subject.ssh_hosts(group_name, hosts)
+      assert_equal hosts, subject.ssh_hosts(group_name)
+
+      exp = { group_name => hosts }
+      assert_equal exp, subject.ssh_hosts
+    end
+
+    should "know its ssh args" do
+      args = Factory.string
+
+      assert_equal "",   subject.ssh_args
+      assert_equal args, subject.ssh_args(args)
+      assert_equal args, subject.ssh_args
+    end
+
+  end
+
+end

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -60,6 +60,18 @@ module Dk::Remote
       assert_equal @hosts.sort, subject.hosts
     end
 
+    should "complain if not given any hosts" do
+      assert_raises(NoHostsError) do
+        @cmd_class.new(Dk::Local::CmdSpy, @cmd_str, :hosts => nil)
+      end
+      assert_raises(NoHostsError) do
+        @cmd_class.new(Dk::Local::CmdSpy, @cmd_str, :hosts => Factory.integer)
+      end
+      assert_raises(NoHostsError) do
+        @cmd_class.new(Dk::Local::CmdSpy, @cmd_str, :hosts => [])
+      end
+    end
+
     should "know its ssh args" do
       assert_equal @ssh_args, subject.ssh_args
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,7 +1,9 @@
 require 'assert'
 require 'dk/runner'
 
+require 'dk/config'
 require 'dk/has_set_param'
+require 'dk/has_ssh_opts'
 require 'dk/local'
 require 'dk/null_logger'
 require 'dk/remote'
@@ -18,6 +20,10 @@ class Dk::Runner
 
     should "include HasSetParam" do
       assert_includes Dk::HasSetParam, subject
+    end
+
+    should "include HasSSHOpts" do
+      assert_includes Dk::HasSSHOpts, subject
     end
 
   end
@@ -44,8 +50,11 @@ class Dk::Runner
     end
 
     should "default its attrs" do
-      exp = {}
-      assert_equal exp, @runner_class.new.params
+      runner = @runner_class.new
+
+      assert_equal Hash.new,                      runner.params
+      assert_equal Dk::Config::DEFAULT_SSH_HOSTS, runner.ssh_hosts
+      assert_equal Dk::Config::DEFAULT_SSH_ARGS,  runner.ssh_args
 
       assert_instance_of Dk::NullLogger, @runner_class.new.logger
     end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -216,7 +216,8 @@ class Dk::TestRunner
     def remote_cmd_opts
       @remote_cmd_opts ||= {
         Factory.string => Factory.string,
-        :hosts         => Factory.hosts
+        :hosts         => Factory.hosts,
+        :ssh_args      => Factory.string
       }
     end
 


### PR DESCRIPTION
This ties together all of the ssh options and handling and allows
for using the ssh opts that have been configured.  This includes
a bunch of small stuff:
- the config runners use the config's ssh opts
- commonized handling of ssh hosts/args between the Config and
  Runner.  This allows you to set ssh hosts/args in Tasks like
  you would in the Config.
- the Task now has a `ssh_hosts` DSL method for configuring a
  default hosts value to apply to all `ssh` cmds made from the
  Task.  If no, hosts are given, the ssh cmd will lookup its hosts
  from this setting.  If this is set with a proc, that proc will
  be instance eval'd on the task, meaning you can set hosts values
  to a task param value or based on specific task logic.  This
  setting will try to lookup a set of named hosts on the config,
  You can now also specify a custom named hosts when making the
  ssh cmd.
- the remote cmd now complains if initialized with no hosts.  This
  helps protect you from making ssh cmds that don't run on any
  hosts.  The exception should alert the user that this has is
  occurring.
- The README has been updated to include the new Task API changes.

This is all part of getting the ssh handling fully in place.

@jcredding ready for review.  Are you cool with how this has all come together?  Do you have a clear understanding of how the ssh hosts/args can be configured/specified?
