### PR TITLE
add a `task` DSL method to Config for adding "callable" tasks

### DIFF
--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -1,5 +1,6 @@
 require 'dk/has_set_param'
 require 'dk/has_ssh_opts'
+require 'dk/task'
 
 module Dk
 
@@ -11,14 +12,16 @@ module Dk
     DEFAULT_PARAMS     = {}.freeze
     DEFAULT_SSH_HOSTS  = {}.freeze
     DEFAULT_SSH_ARGS   = ''.freeze
+    DEFAULT_TASKS      = {}.freeze
 
-    attr_reader :init_procs, :params
+    attr_reader :init_procs, :params, :tasks
 
     def initialize
       @init_procs = DEFAULT_INIT_PROCS.dup
       @params     = DEFAULT_PARAMS.dup
       @ssh_hosts  = DEFAULT_SSH_HOSTS.dup
       @ssh_args   = DEFAULT_SSH_ARGS.dup
+      @tasks      = DEFAULT_TASKS.dup
     end
 
     def init
@@ -43,6 +46,13 @@ module Dk
 
     def prepend_after(subject_task_class, callback_task_class, params = nil)
       subject_task_class.prepend_after(callback_task_class, params)
+    end
+
+    def task(name, task_class)
+      if !task_class.kind_of?(Class) || !task_class.include?(Dk::Task)
+        raise ArgumentError, "#{task_class.inspect} is not a Dk::Task"
+      end
+      @tasks[name.to_s] = task_class
     end
 
   end


### PR DESCRIPTION
This is prep for adding a CLI to run these "callable" tasks.  We
need a way to map CLI-friendly name strings to task classes that
can be run.  Only task classes "routed" in the config will be
callable by the CLI.

@jcredding ready for review.
