### PR TITLE
add host-specific ssh args to Config DSL; honor when making ssh cmds

### DIFF
--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -8,20 +8,22 @@ module Dk
     include Dk::HasSetParam
     include Dk::HasSSHOpts
 
-    DEFAULT_INIT_PROCS = [].freeze
-    DEFAULT_PARAMS     = {}.freeze
-    DEFAULT_SSH_HOSTS  = {}.freeze
-    DEFAULT_SSH_ARGS   = ''.freeze
-    DEFAULT_TASKS      = {}.freeze
+    DEFAULT_INIT_PROCS    = [].freeze
+    DEFAULT_PARAMS        = {}.freeze
+    DEFAULT_SSH_HOSTS     = {}.freeze
+    DEFAULT_SSH_ARGS      = ''.freeze
+    DEFAULT_HOST_SSH_ARGS = Hash.new{ |h, k| h[k] = DEFAULT_SSH_ARGS }
+    DEFAULT_TASKS         = {}.freeze
 
     attr_reader :init_procs, :params, :tasks
 
     def initialize
-      @init_procs = DEFAULT_INIT_PROCS.dup
-      @params     = DEFAULT_PARAMS.dup
-      @ssh_hosts  = DEFAULT_SSH_HOSTS.dup
-      @ssh_args   = DEFAULT_SSH_ARGS.dup
-      @tasks      = DEFAULT_TASKS.dup
+      @init_procs    = DEFAULT_INIT_PROCS.dup
+      @params        = DEFAULT_PARAMS.dup
+      @ssh_hosts     = DEFAULT_SSH_HOSTS.dup
+      @ssh_args      = DEFAULT_SSH_ARGS.dup
+      @host_ssh_args = DEFAULT_HOST_SSH_ARGS.dup
+      @tasks         = DEFAULT_TASKS.dup
     end
 
     def init

--- a/lib/dk/config_runner.rb
+++ b/lib/dk/config_runner.rb
@@ -6,9 +6,10 @@ module Dk
 
     def initialize(config)
       super({
-        :params    => config.params,
-        :ssh_hosts => config.ssh_hosts,
-        :ssh_args  => config.ssh_args
+        :params        => config.params,
+        :ssh_hosts     => config.ssh_hosts,
+        :ssh_args      => config.ssh_args,
+        :host_ssh_args => config.host_ssh_args
       })
     end
 

--- a/lib/dk/has_ssh_opts.rb
+++ b/lib/dk/has_ssh_opts.rb
@@ -23,6 +23,12 @@ module Dk
         @ssh_args
       end
 
+      def host_ssh_args(host_name = nil, value = nil)
+        return @host_ssh_args if host_name.nil?
+        @host_ssh_args[host_name.to_s] = value if !value.nil?
+        @host_ssh_args[host_name.to_s]
+      end
+
     end
 
   end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -18,8 +18,9 @@ module Dk
       @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
       @params.merge!(dk_normalize_params(opts[:params]))
 
-      @ssh_hosts = opts[:ssh_hosts] || Config::DEFAULT_SSH_HOSTS.dup
-      @ssh_args  = opts[:ssh_args]  || Config::DEFAULT_SSH_ARGS.dup
+      @ssh_hosts     = opts[:ssh_hosts]     || Config::DEFAULT_SSH_HOSTS.dup
+      @ssh_args      = opts[:ssh_args]      || Config::DEFAULT_SSH_ARGS.dup
+      @host_ssh_args = opts[:host_ssh_args] || Config::DEFAULT_HOST_SSH_ARGS.dup
 
       @logger = opts[:logger] || NullLogger.new
     end

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -95,8 +95,9 @@ module Dk
       def dk_build_ssh_opts(opts)
         opts ||= {}
         opts.merge({
-          :hosts    => dk_lookup_ssh_hosts(opts[:hosts]),
-          :ssh_args => dk_lookup_ssh_args(opts[:ssh_args])
+          :hosts         => dk_lookup_ssh_hosts(opts[:hosts]),
+          :ssh_args      => dk_lookup_ssh_args(opts[:ssh_args]),
+          :host_ssh_args => dk_lookup_host_ssh_args(opts[:host_ssh_args]),
         })
       end
 
@@ -113,6 +114,10 @@ module Dk
 
       def dk_lookup_ssh_args(opts_args)
         opts_args || @dk_runner.ssh_args
+      end
+
+      def dk_lookup_host_ssh_args(opts_args)
+        opts_args || @dk_runner.host_ssh_args
       end
 
     end

--- a/test/unit/config_runner_tests.rb
+++ b/test/unit/config_runner_tests.rb
@@ -28,9 +28,10 @@ class Dk::ConfigRunner
     subject{ @runner }
 
     should "initialize using the config's values" do
-      assert_equal @config.params,    subject.params
-      assert_equal @config.ssh_hosts, subject.ssh_hosts
-      assert_equal @config.ssh_args,  subject.ssh_args
+      assert_equal @config.params,        subject.params
+      assert_equal @config.ssh_hosts,     subject.ssh_hosts
+      assert_equal @config.ssh_args,      subject.ssh_args
+      assert_equal @config.host_ssh_args, subject.host_ssh_args
     end
 
   end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -27,6 +27,7 @@ class Dk::Config
       assert_equal Hash.new,  subject::DEFAULT_PARAMS
       assert_equal Hash.new,  subject::DEFAULT_SSH_HOSTS
       assert_equal '',        subject::DEFAULT_SSH_ARGS
+      assert_equal Hash.new,  subject::DEFAULT_HOST_SSH_ARGS
       assert_equal Hash.new,  subject::DEFAULT_TASKS
     end
 
@@ -45,11 +46,12 @@ class Dk::Config
     should have_imeths :task
 
     should "default its attrs" do
-      assert_equal @config_class::DEFAULT_INIT_PROCS, subject.init_procs
-      assert_equal @config_class::DEFAULT_PARAMS,     subject.params
-      assert_equal @config_class::DEFAULT_SSH_HOSTS,  subject.ssh_hosts
-      assert_equal @config_class::DEFAULT_SSH_ARGS,   subject.ssh_args
-      assert_equal @config_class::DEFAULT_TASKS,      subject.tasks
+      assert_equal @config_class::DEFAULT_INIT_PROCS,    subject.init_procs
+      assert_equal @config_class::DEFAULT_PARAMS,        subject.params
+      assert_equal @config_class::DEFAULT_SSH_HOSTS,     subject.ssh_hosts
+      assert_equal @config_class::DEFAULT_SSH_ARGS,      subject.ssh_args
+      assert_equal @config_class::DEFAULT_HOST_SSH_ARGS, subject.host_ssh_args
+      assert_equal @config_class::DEFAULT_TASKS,         subject.tasks
     end
 
     should "instance eval its init procs on init" do

--- a/test/unit/has_ssh_opts_tests.rb
+++ b/test/unit/has_ssh_opts_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'dk/has_ssh_opts'
 
 require 'much-plugin'
+require 'dk/config'
 
 module Dk::HasSSHOpts
 
@@ -13,8 +14,9 @@ module Dk::HasSSHOpts
       @opts_class = Class.new do
         include Dk::HasSSHOpts
         def initialize
-          @ssh_hosts = {}
-          @ssh_args  = ''
+          @ssh_hosts     = Dk::Config::DEFAULT_SSH_HOSTS.dup
+          @ssh_args      = Dk::Config::DEFAULT_SSH_ARGS.dup
+          @host_ssh_args = Dk::Config::DEFAULT_HOST_SSH_ARGS.dup
         end
       end
     end
@@ -33,7 +35,7 @@ module Dk::HasSSHOpts
     end
     subject{ @opts }
 
-    should have_imeths :ssh_hosts, :ssh_args
+    should have_imeths :ssh_hosts, :ssh_args, :host_ssh_args
 
     should "know its ssh hosts" do
       group_name = Factory.string
@@ -55,6 +57,20 @@ module Dk::HasSSHOpts
       assert_equal "",   subject.ssh_args
       assert_equal args, subject.ssh_args(args)
       assert_equal args, subject.ssh_args
+    end
+
+    should "know its host ssh args" do
+      host_name = Factory.string
+      args      = Factory.string
+
+      assert_equal Hash.new, subject.host_ssh_args
+      assert_equal Dk::Config::DEFAULT_SSH_ARGS, subject.host_ssh_args(host_name)
+
+      assert_equal args, subject.host_ssh_args(host_name, args)
+      assert_equal args, subject.host_ssh_args(host_name)
+
+      exp = { host_name => args }
+      assert_equal exp, subject.host_ssh_args
     end
 
   end

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -8,14 +8,16 @@ module Dk::Remote
   class UnitTests < Assert::Context
     desc "Dk::Remote"
     setup do
-      @hosts    = Factory.hosts
-      @ssh_args = Factory.string
-      @cmd_str  = Factory.string
+      @hosts         = Factory.hosts
+      @ssh_args      = Factory.string
+      @host_ssh_args = { @hosts.sample => Factory.string }
+      @cmd_str       = Factory.string
 
       @opts = {
         :env           => Factory.string,
         :hosts         => @hosts,
         :ssh_args      => @ssh_args,
+        :host_ssh_args => @host_ssh_args,
         Factory.string => Factory.string
       }
 
@@ -39,9 +41,9 @@ module Dk::Remote
 
     private
 
-    def ssh_cmd_str(cmd_str, host, args)
+    def ssh_cmd_str(cmd_str, host, args, host_args)
       val = "\"#{cmd_str}\"".gsub("\\", "\\\\\\").gsub('"', '\"')
-      "ssh #{args} #{host} -- \"sh -c #{val}\""
+      "ssh #{args} #{host_args[host]} #{host} -- \"sh -c #{val}\""
     end
 
   end
@@ -53,7 +55,7 @@ module Dk::Remote
       @cmd = @cmd_class.new(Dk::Local::CmdSpy, @cmd_str, @opts)
     end
 
-    should have_readers :hosts, :ssh_args, :cmd_str, :local_cmds
+    should have_readers :hosts, :ssh_args, :host_ssh_args, :cmd_str, :local_cmds
     should have_imeths :to_s, :run, :success?, :output_lines
 
     should "know its hosts" do
@@ -73,7 +75,8 @@ module Dk::Remote
     end
 
     should "know its ssh args" do
-      assert_equal @ssh_args, subject.ssh_args
+      assert_equal @ssh_args,      subject.ssh_args
+      assert_equal @host_ssh_args, subject.host_ssh_args
     end
 
     should "know its cmd str" do
@@ -84,20 +87,30 @@ module Dk::Remote
     should "build a local cmd for each of its hosts" do
       subject.hosts.each do |host|
         assert_instance_of Dk::Local::CmdSpy, subject.local_cmds[host]
-        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args)
+        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args, subject.host_ssh_args)
         assert_equal exp, subject.local_cmds[host].cmd_str
       end
-      exp_cmd_str = ssh_cmd_str(@cmd_str, subject.hosts.last, subject.ssh_args)
+      exp_cmd_str = ssh_cmd_str(
+        @cmd_str,
+        subject.hosts.last,
+        subject.ssh_args,
+        subject.host_ssh_args
+      )
       exp_opts    = { :env => @opts[:env] }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_spy_new_called_with
 
       cmd = @cmd_class.new(Dk::Local::Cmd, @cmd_str, @opts)
       cmd.hosts.each do |host|
         assert_instance_of Dk::Local::Cmd, cmd.local_cmds[host]
-        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args)
-        assert_equal exp, subject.local_cmds[host].cmd_str
+        exp = ssh_cmd_str(@cmd_str, host, cmd.ssh_args, cmd.host_ssh_args)
+        assert_equal exp, cmd.local_cmds[host].cmd_str
       end
-      exp_cmd_str = ssh_cmd_str(@cmd_str, cmd.hosts.last, cmd.ssh_args)
+      exp_cmd_str = ssh_cmd_str(
+        @cmd_str,
+        cmd.hosts.last,
+        cmd.ssh_args,
+        cmd.host_ssh_args
+      )
       exp_opts    = { :env => @opts[:env] }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_new_called_with
     end
@@ -160,21 +173,31 @@ module Dk::Remote
     should "build a local cmd for each host with the cmd str, given opts" do
       subject.hosts.each do |host|
         assert_instance_of Dk::Local::Cmd, subject.local_cmds[host]
-        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args)
+        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args, subject.host_ssh_args)
         assert_equal exp, subject.local_cmds[host].cmd_str
       end
-      exp_cmd_str = ssh_cmd_str(@cmd_str, subject.hosts.last, subject.ssh_args)
-      exp_opts    = { :env => nil }
+      exp_cmd_str = ssh_cmd_str(
+        @cmd_str,
+        subject.hosts.last,
+        subject.ssh_args,
+        subject.host_ssh_args
+      )
+      exp_opts = { :env => nil }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_new_called_with
 
       cmd  = @cmd_class.new(@cmd_str, @opts)
       cmd.hosts.each do |host|
         assert_instance_of Dk::Local::Cmd, cmd.local_cmds[host]
-        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args)
-        assert_equal exp, subject.local_cmds[host].cmd_str
+        exp = ssh_cmd_str(@cmd_str, host, cmd.ssh_args, cmd.host_ssh_args)
+        assert_equal exp, cmd.local_cmds[host].cmd_str
       end
-      exp_cmd_str = ssh_cmd_str(@cmd_str, cmd.hosts.last, cmd.ssh_args)
-      exp_opts    = { :env => @opts[:env] }
+      exp_cmd_str = ssh_cmd_str(
+        @cmd_str,
+        cmd.hosts.last,
+        cmd.ssh_args,
+        cmd.host_ssh_args
+      )
+      exp_opts = { :env => @opts[:env] }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_new_called_with
     end
 
@@ -194,21 +217,31 @@ module Dk::Remote
     should "build a local cmd spy for each host with the cmd str, given opts" do
       subject.hosts.each do |host|
         assert_instance_of Dk::Local::CmdSpy, subject.local_cmds[host]
-        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args)
+        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args, subject.host_ssh_args)
         assert_equal exp, subject.local_cmds[host].cmd_str
       end
-      exp_cmd_str = ssh_cmd_str(@cmd_str, subject.hosts.last, subject.ssh_args)
-      exp_opts    = { :env => nil }
+      exp_cmd_str = ssh_cmd_str(
+        @cmd_str,
+        subject.hosts.last,
+        subject.ssh_args,
+        subject.host_ssh_args
+      )
+      exp_opts = { :env => nil }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_spy_new_called_with
 
       cmd  = @cmd_class.new(@cmd_str, @opts)
       cmd.hosts.each do |host|
         assert_instance_of Dk::Local::CmdSpy, cmd.local_cmds[host]
-        exp = ssh_cmd_str(@cmd_str, host, subject.ssh_args)
-        assert_equal exp, subject.local_cmds[host].cmd_str
+        exp = ssh_cmd_str(@cmd_str, host, cmd.ssh_args, cmd.host_ssh_args)
+        assert_equal exp, cmd.local_cmds[host].cmd_str
       end
-      exp_cmd_str = ssh_cmd_str(@cmd_str, cmd.hosts.last, cmd.ssh_args)
-      exp_opts    = { :env => @opts[:env] }
+      exp_cmd_str = ssh_cmd_str(
+        @cmd_str,
+        cmd.hosts.last,
+        cmd.ssh_args,
+        cmd.host_ssh_args
+      )
+      exp_opts = { :env => @opts[:env] }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_spy_new_called_with
     end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -52,9 +52,10 @@ class Dk::Runner
     should "default its attrs" do
       runner = @runner_class.new
 
-      assert_equal Hash.new,                      runner.params
-      assert_equal Dk::Config::DEFAULT_SSH_HOSTS, runner.ssh_hosts
-      assert_equal Dk::Config::DEFAULT_SSH_ARGS,  runner.ssh_args
+      assert_equal Hash.new,                          runner.params
+      assert_equal Dk::Config::DEFAULT_SSH_HOSTS,     runner.ssh_hosts
+      assert_equal Dk::Config::DEFAULT_SSH_ARGS,      runner.ssh_args
+      assert_equal Dk::Config::DEFAULT_HOST_SSH_ARGS, runner.host_ssh_args
 
       assert_instance_of Dk::NullLogger, @runner_class.new.logger
     end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -216,7 +216,8 @@ module Dk::Task
       cmd_opts = {
         Factory.string => Factory.string,
         :hosts         => Factory.hosts,
-        :ssh_args      => Factory.string
+        :ssh_args      => Factory.string,
+        :host_ssh_args => { Factory.string => Factory.string }
       }
       subject.instance_eval{ ssh(cmd_str, cmd_opts) }
 
@@ -237,7 +238,8 @@ module Dk::Task
       cmd_opts = {
         Factory.string => Factory.string,
         :hosts         => Factory.hosts,
-        :ssh_args      => Factory.string
+        :ssh_args      => Factory.string,
+        :host_ssh_args => { Factory.string => Factory.string }
       }
 
       err = assert_raises(SSHRunError) do
@@ -325,6 +327,19 @@ module Dk::Task
 
       task.instance_eval{ ssh(Factory.string) }
       assert_equal args, runner_ssh_called_with_opts[:ssh_args]
+    end
+
+    should "use the runner's host ssh args if none are given" do
+      args       = { Factory.string => Factory.string }
+      task_class = Class.new{ include Dk::Task }
+      runner     = test_runner(task_class, :host_ssh_args => args)
+      task       = runner.task
+
+      runner_ssh_called_with_opts = nil
+      Assert.stub(runner, :ssh){ |_, opts| runner_ssh_called_with_opts = opts }
+
+      task.instance_eval{ ssh(Factory.string) }
+      assert_equal args, runner_ssh_called_with_opts[:host_ssh_args]
     end
 
   end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -217,7 +217,8 @@ class Dk::TestRunner
       @remote_cmd_opts ||= {
         Factory.string => Factory.string,
         :hosts         => Factory.hosts,
-        :ssh_args      => Factory.string
+        :ssh_args      => Factory.string,
+        :host_ssh_args => { Factory.string => Factory.string }
       }
     end
 


### PR DESCRIPTION
This allows users to set ssh args that are only needed/applicable
to specific hosts.  This could be things like one host uses a
custom SSH port while the rest do not, etc.

This adds a new DSL method, `host_ssh_args` to the Config DSL.
Given a host name and the args, it stores them off.  That data is
then sent to the runner who passes it on to the Remote::Cmd.  The
remote cmd inserts the args after the global args on the local
cmd for the given host.

See #26 for reference as this effort was spawned from discussion there.

@jcredding ready for review.
