### PR TITLE
build a Logsly logger from a config and use on the live/dry runners

### DIFF
--- a/dk.gemspec
+++ b/dk.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
   gem.add_dependency("scmd",        ["~> 3.0.2"])
+  gem.add_dependency("logsly",      ["~> 1.3.2"])
 
 end

--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -1,3 +1,4 @@
+require 'logsly'
 require 'dk/has_set_param'
 require 'dk/has_ssh_opts'
 require 'dk/task'
@@ -8,22 +9,30 @@ module Dk
     include Dk::HasSetParam
     include Dk::HasSSHOpts
 
-    DEFAULT_INIT_PROCS    = [].freeze
-    DEFAULT_PARAMS        = {}.freeze
-    DEFAULT_SSH_HOSTS     = {}.freeze
-    DEFAULT_SSH_ARGS      = ''.freeze
-    DEFAULT_HOST_SSH_ARGS = Hash.new{ |h, k| h[k] = DEFAULT_SSH_ARGS }
-    DEFAULT_TASKS         = {}.freeze
+    DEFAULT_INIT_PROCS       = [].freeze
+    DEFAULT_PARAMS           = {}.freeze
+    DEFAULT_SSH_HOSTS        = {}.freeze
+    DEFAULT_SSH_ARGS         = ''.freeze
+    DEFAULT_HOST_SSH_ARGS    = Hash.new{ |h, k| h[k] = DEFAULT_SSH_ARGS }
+    DEFAULT_TASKS            = {}.freeze
+    DEFAULT_LOG_PATTERN      = "%m\n".freeze
+    DEFAULT_LOG_FILE_PATTERN = '[%d %-5l] : %m\n'.freeze
+
+    STDOUT_LOG_LEVEL = 'info'.freeze
+    FILE_LOG_LEVEL   = 'debug'.freeze
 
     attr_reader :init_procs, :params, :tasks
 
     def initialize
-      @init_procs    = DEFAULT_INIT_PROCS.dup
-      @params        = DEFAULT_PARAMS.dup
-      @ssh_hosts     = DEFAULT_SSH_HOSTS.dup
-      @ssh_args      = DEFAULT_SSH_ARGS.dup
-      @host_ssh_args = DEFAULT_HOST_SSH_ARGS.dup
-      @tasks         = DEFAULT_TASKS.dup
+      @init_procs       = DEFAULT_INIT_PROCS.dup
+      @params           = DEFAULT_PARAMS.dup
+      @ssh_hosts        = DEFAULT_SSH_HOSTS.dup
+      @ssh_args         = DEFAULT_SSH_ARGS.dup
+      @host_ssh_args    = DEFAULT_HOST_SSH_ARGS.dup
+      @tasks            = DEFAULT_TASKS.dup
+      @log_pattern      = DEFAULT_LOG_PATTERN
+      @log_file         = nil
+      @log_file_pattern = DEFAULT_LOG_FILE_PATTERN
     end
 
     def init
@@ -55,6 +64,67 @@ module Dk
         raise ArgumentError, "#{task_class.inspect} is not a Dk::Task"
       end
       @tasks[name.to_s] = task_class
+    end
+
+    def log_pattern(value = nil)
+      @log_pattern = value if !value.nil?
+      @log_pattern
+    end
+
+    def log_file(value = nil)
+      @log_file = value if !value.nil?
+      @log_file
+    end
+
+    def log_file_pattern(value = nil)
+      @log_file_pattern = value if !value.nil?
+      @log_file_pattern
+    end
+
+    # private - intended for internal use only
+
+    def dk_logger_stdout_output_name
+      # include the object id to ensure the output is unique to the instance
+      @dk_logger_stdout_output_name ||= "dk-config-#{self.object_id}-stdout"
+    end
+
+    def dk_logger_file_output_name
+      # include the object id to ensure the output is unique to the instance
+      @dk_logger_file_output_name ||= "dk-config-#{self.object_id}-file"
+    end
+
+    def dk_logger
+      @dk_logger ||= LogslyLogger.new(self)
+    end
+
+    class LogslyLogger
+      include Logsly
+
+      LOG_TYPE = 'dk'.freeze
+
+      attr_reader :config
+
+      def initialize(config)
+        @config = config # set the reader first so it can be used when supering
+
+        Logsly.stdout(@config.dk_logger_stdout_output_name) do |logger|
+          level   Dk::Config::STDOUT_LOG_LEVEL
+          pattern logger.config.log_pattern
+        end
+        outputs = [@config.dk_logger_stdout_output_name]
+
+        if @config.log_file
+          Logsly.file(@config.dk_logger_file_output_name) do |logger|
+            path    File.expand_path(logger.config.log_file, ENV['PWD'])
+            level   Dk::Config::FILE_LOG_LEVEL
+            pattern logger.config.log_file_pattern
+          end
+          outputs << @config.dk_logger_file_output_name
+        end
+
+        super(LOG_TYPE, :outputs => outputs)
+      end
+
     end
 
   end

--- a/lib/dk/config_runner.rb
+++ b/lib/dk/config_runner.rb
@@ -4,12 +4,14 @@ module Dk
 
   class ConfigRunner < Runner
 
-    def initialize(config)
+    def initialize(config, opts = nil)
+      opts ||= {}
       super({
         :params        => config.params,
         :ssh_hosts     => config.ssh_hosts,
         :ssh_args      => config.ssh_args,
-        :host_ssh_args => config.host_ssh_args
+        :host_ssh_args => config.host_ssh_args,
+        :logger        => opts[:logger] || config.dk_logger
       })
     end
 

--- a/lib/dk/dk_runner.rb
+++ b/lib/dk/dk_runner.rb
@@ -3,6 +3,11 @@ require 'dk/config_runner'
 module Dk
 
   class DkRunner < ConfigRunner
+
+    def initialize(config)
+      super(config)
+    end
+
   end
 
 end

--- a/lib/dk/tree_runner.rb
+++ b/lib/dk/tree_runner.rb
@@ -1,5 +1,6 @@
 require 'dk/dry_runner'
 require 'dk/has_the_runs'
+require 'dk/null_logger'
 require 'dk/task_run'
 
 module Dk
@@ -7,17 +8,15 @@ module Dk
   class TreeRunner < DryRunner
     include HasTheRuns
 
-    def initialize(*args)
-      super
+    def initialize(config)
+      super(config, :logger => NullLogger.new) # disable any logging
       @task_run_stack = [self]
     end
 
     def run(*args)
       super
-      # TODO: log out view of nested task runs
+      # TODO: puts out view of nested task runs
     end
-
-    # TODO: disable any logging
 
     private
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,9 @@
 # put any test helpers here
 
 # add the root dir to the load path
-$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
+require 'pathname'
+ROOT_PATH = Pathname.new(File.expand_path("../..", __FILE__))
+$LOAD_PATH.unshift(ROOT_PATH)
 
 # require pry for debugging (`binding.pry`)
 require 'pry'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -19,4 +19,8 @@ module Factory
     Factory.integer(3).times.map{ "#{Factory.string}.example.com" }
   end
 
+  def self.log_file
+    ROOT_PATH.join("test/support/log/#{Factory.string}.txt")
+  end
+
 end

--- a/test/unit/config_runner_tests.rb
+++ b/test/unit/config_runner_tests.rb
@@ -23,15 +23,22 @@ class Dk::ConfigRunner
     desc "when init"
     setup do
       @config = Dk::Config.new
-      @runner = @runner_class.new(@config)
     end
-    subject{ @runner }
 
     should "initialize using the config's values" do
-      assert_equal @config.params,        subject.params
-      assert_equal @config.ssh_hosts,     subject.ssh_hosts
-      assert_equal @config.ssh_args,      subject.ssh_args
-      assert_equal @config.host_ssh_args, subject.host_ssh_args
+      runner = @runner_class.new(@config)
+
+      assert_equal @config.params,        runner.params
+      assert_equal @config.ssh_hosts,     runner.ssh_hosts
+      assert_equal @config.ssh_args,      runner.ssh_args
+      assert_equal @config.host_ssh_args, runner.host_ssh_args
+      assert_equal @config.dk_logger,     runner.logger
+    end
+
+    should "honor any custom logger option" do
+      logger = Factory.string
+      runner = @runner_class.new(@config, :logger => logger)
+      assert_equal logger, runner.logger
     end
 
   end

--- a/test/unit/dk_runner_tests.rb
+++ b/test/unit/dk_runner_tests.rb
@@ -18,4 +18,17 @@ class Dk::DkRunner
 
   end
 
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @config = Dk::Config.new
+    end
+
+    should "be init with a config instance" do
+      assert_nothing_raised{ @runner_class.new(@config) }
+      assert_raises(ArgumentError){ @runner_class.new }
+    end
+
+  end
+
 end

--- a/test/unit/has_ssh_opts_tests.rb
+++ b/test/unit/has_ssh_opts_tests.rb
@@ -41,7 +41,7 @@ module Dk::HasSSHOpts
       group_name = Factory.string
       hosts      = Factory.hosts
 
-      assert_equal Hash.new, subject.ssh_hosts
+      assert_equal Dk::Config::DEFAULT_SSH_HOSTS, subject.ssh_hosts
       assert_nil subject.ssh_hosts(group_name)
 
       assert_equal hosts, subject.ssh_hosts(group_name, hosts)
@@ -54,7 +54,7 @@ module Dk::HasSSHOpts
     should "know its ssh args" do
       args = Factory.string
 
-      assert_equal "",   subject.ssh_args
+      assert_equal Dk::Config::DEFAULT_SSH_ARGS, subject.ssh_args
       assert_equal args, subject.ssh_args(args)
       assert_equal args, subject.ssh_args
     end

--- a/test/unit/tree_runner_tests.rb
+++ b/test/unit/tree_runner_tests.rb
@@ -4,6 +4,7 @@ require 'dk/tree_runner'
 require 'dk/config'
 require 'dk/dry_runner'
 require 'dk/has_the_runs'
+require 'dk/null_logger'
 require 'dk/task'
 require 'dk/task_run'
 
@@ -33,6 +34,10 @@ class Dk::TreeRunner
       @runner = @runner_class.new(config)
     end
     subject{ @runner }
+
+    should "force a null logger to disable logging" do
+      assert_instance_of Dk::NullLogger, subject.logger
+    end
 
   end
 


### PR DESCRIPTION
This configured logsly logger will handle logging output to stdout
and optionally to a file when running tasks live in in dry-run
mode.

This adds a few config DSL methods to help control the logger. Use
`log_pattern` to change the pattern when logging to stdout. By
default only the log message will be output.  All stdout logging
will be at the INFO level unless in verbose mode then logging will
be at the DEBUG level.  Use `log_file` to turn on logging to a
file by setting a log file path relative to the PWD.  This is
optional.  All file logging will be at the DEBUG level, regardless
of whether in verbose mode or not.  The idea is that you can set
a log file to ensure you can always access the verbose details of
a task run while just using the non-verbose default on stdout.
Finally, use the `log_file_pattern` to change the pattern when
file logging.  By default the date, level and message will be
output.

This updates the ConfigRunner (used by the live, dry and tree
runners) to super with the config's logger unless a custom logger
has been given.  The TreeRunner now passes a NullLogger to turn
off logger (per its requirements).

See redding/logsly#9 for reference.  This requires this patch as it allows for custom logger levels per configured output.

@jcredding ready for review.
