### PR TITLE
add first-pass README docs for the config DSL

### DIFF
--- a/lib/dk/has_ssh_opts.rb
+++ b/lib/dk/has_ssh_opts.rb
@@ -12,9 +12,9 @@ module Dk
 
     module InstanceMethods
 
-      def ssh_hosts(group_name = nil, value = nil)
+      def ssh_hosts(group_name = nil, *values)
         return @ssh_hosts if group_name.nil?
-        @ssh_hosts[group_name.to_s] = value if !value.nil?
+        @ssh_hosts[group_name.to_s] = values.flatten if !values.empty?
         @ssh_hosts[group_name.to_s]
       end
 

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -80,8 +80,8 @@ module Dk
         @dk_runner.set_param(key, value)
       end
 
-      def ssh_hosts(group_name = nil, value = nil)
-        @dk_runner.ssh_hosts(group_name, value)
+      def ssh_hosts(group_name = nil, *values)
+        @dk_runner.ssh_hosts(group_name, *values)
       end
 
       def halt

--- a/test/unit/has_ssh_opts_tests.rb
+++ b/test/unit/has_ssh_opts_tests.rb
@@ -47,6 +47,9 @@ module Dk::HasSSHOpts
       assert_equal hosts, subject.ssh_hosts(group_name, hosts)
       assert_equal hosts, subject.ssh_hosts(group_name)
 
+      assert_equal hosts, subject.ssh_hosts(group_name, *hosts)
+      assert_equal hosts, subject.ssh_hosts(group_name)
+
       exp = { group_name => hosts }
       assert_equal exp, subject.ssh_hosts
     end


### PR DESCRIPTION
This is part of documenting Dk and its usage.  This covers the
Config and its DSL.  This also includes a number of tweaks to the
previous docs to generally improve them and make them more
readable.

In addition, I updated the `ssh_hosts` api to take a variable list
of values instead of forcing the values to be passed in as a
single array.  As I was adding example usage docs I found it was
a better way to configure long lists of servers.  This is also
backwards compatible with the previous single array API.

@jcredding ready for review.  I went ahead and put in docs for the stuff in #29.  Does all this make sense to you?  Did I miss anything as far as you can tell?
