### PR TITLE
basic CLI with runner flags and list tasks options

### DIFF
--- a/bin/dk
+++ b/bin/dk
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+#
+# Copyright (c) 2016 Kelly Redding & Collin Redding
+#
+
+require 'dk/cli'
+Dk::CLI.run ARGV

--- a/lib/dk.rb
+++ b/lib/dk.rb
@@ -16,4 +16,8 @@ module Dk
     self.config.init
   end
 
+  def self.reset
+    @config = Config.new
+  end
+
 end

--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -1,0 +1,149 @@
+require 'dk'
+require 'dk/dk_runner'
+require 'dk/dry_runner'
+require 'dk/tree_runner'
+require 'dk/version'
+
+module Dk
+
+  class CLI
+
+    DEFAULT_CONFIG_PATH = 'config/tasks.rb'.freeze
+
+    def self.run(args)
+      self.new.run(*args)
+    end
+
+    attr_reader :clirb
+
+    def initialize(kernel = nil)
+      @kernel = kernel || Kernel
+
+      load config_path
+      Dk.init
+      @config = Dk.config
+
+      @clirb = CLIRB.new do
+        option 'list-tasks', 'list all tasks available to run', {
+          :abbrev => 'T'
+        }
+        option 'dry-run', 'run the tasks without executing any local/remote cmds'
+        option 'tree',    'print out the tree of tasks/sub-tasks that would be run'
+      end
+    end
+
+    def run(*args)
+      begin
+        run!(*args)
+      rescue ShowTaskList
+        @kernel.puts task_list
+      rescue CLIRB::HelpExit
+        @kernel.puts help
+      rescue CLIRB::VersionExit
+        @kernel.puts Dk::VERSION
+      rescue CLIRB::Error, Dk::Config::UnknownTaskError => exception
+        @kernel.puts "#{exception.message}\n\n"
+        @kernel.puts help
+        @kernel.exit 1
+      rescue StandardError => exception
+        @kernel.puts "#{exception.class}: #{exception.message}"
+        @kernel.puts exception.backtrace.join("\n")
+        @kernel.exit 1
+      end
+      @kernel.exit 0
+    end
+
+    private
+
+    def run!(*args)
+      @clirb.parse!(args)
+      raise ShowTaskList if @clirb.opts['list-tasks']
+
+      runner = get_runner(@clirb.opts)
+      @clirb.args.each{ |task_name| runner.run(@config.task(task_name)) }
+    end
+
+    def help
+      "Usage: dk [TASKS] [options]\n\n" \
+      "Tasks:\n" \
+      "#{task_list}\n\n" \
+      "Options: #{@clirb}"
+    end
+
+    def task_list
+      "TODO: task list here"
+    end
+
+    def config_path
+      File.expand_path(ENV['DK_CONFIG'] || DEFAULT_CONFIG_PATH, ENV['PWD'])
+    end
+
+    def get_runner(opts)
+      if opts['dry-run'] || opts['tree']
+        ENV['SCMD_TEST_MODE'] = '1' # disable all local/remote cmds
+      end
+      return Dk::DryRunner.new(@config) if opts['dry-run']
+      return Dk::TreeRunner.new(@config, @kernel) if opts['tree']
+      Dk::DkRunner.new(@config)
+    end
+
+    ShowTaskList = Class.new(RuntimeError)
+
+  end
+
+  class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
+    Error    = Class.new(RuntimeError);
+    HelpExit = Class.new(RuntimeError); VersionExit = Class.new(RuntimeError)
+    attr_reader :argv, :args, :opts, :data
+
+    def initialize(&block)
+      @options = []; instance_eval(&block) if block
+      require 'optparse'
+      @data, @args, @opts = [], [], {}; @parser = OptionParser.new do |p|
+        p.banner = ''; @options.each do |o|
+          @opts[o.name] = o.value; p.on(*o.parser_args){ |v| @opts[o.name] = v }
+        end
+        p.on_tail('--version', ''){ |v| raise VersionExit, v.to_s }
+        p.on_tail('--help',    ''){ |v| raise HelpExit,    v.to_s }
+      end
+    end
+
+    def option(*args); @options << Option.new(*args); end
+    def parse!(argv)
+      @args = (argv || []).dup.tap do |args_list|
+        begin; @parser.parse!(args_list)
+        rescue OptionParser::ParseError => err; raise Error, err.message; end
+      end; @data = @args + [@opts]
+    end
+    def to_s; @parser.to_s; end
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @data=#{@data.inspect}>"
+    end
+
+    class Option
+      attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
+
+      def initialize(name, *args)
+        settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
+        @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
+        @value, @klass = gvalinfo(settings[:value])
+        @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
+          ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
+        else
+          ["-#{@abbrev}", "--#{@opt_name} #{@opt_name.upcase}", @klass, @desc]
+        end
+      end
+
+      private
+
+      def parse_name_values(name, custom_abbrev)
+        [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
+          custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
+        ]
+      end
+      def gvalinfo(v); v.kind_of?(Class) ? [nil,gklass(v)] : [v,gklass(v.class)]; end
+      def gklass(k); k == Fixnum ? Integer : k; end
+    end
+  end
+
+end

--- a/lib/dk/dry_runner.rb
+++ b/lib/dk/dry_runner.rb
@@ -4,7 +4,7 @@ module Dk
 
   class DryRunner < ConfigRunner
 
-    # TODO: disable any cmds, just log actions, but run all sub-tasks
+    # run with disabled cmds, just log actions, but run all sub-tasks
 
   end
 

--- a/lib/dk/tree_runner.rb
+++ b/lib/dk/tree_runner.rb
@@ -8,14 +8,17 @@ module Dk
   class TreeRunner < DryRunner
     include HasTheRuns
 
-    def initialize(config)
+    def initialize(config, kernel)
       super(config, :logger => NullLogger.new) # disable any logging
+
       @task_run_stack = [self]
+      @kernel         = kernel
     end
 
     def run(*args)
-      super
-      # TODO: puts out view of nested task runs
+      task = super
+      @kernel.puts "TODO: task tree output goes here"
+      task
     end
 
     private

--- a/test/support/config/task_defs.rb
+++ b/test/support/config/task_defs.rb
@@ -1,0 +1,10 @@
+class CLITestTask
+  include Dk::Task
+
+end
+
+class CLIOtherTask
+  include Dk::Task
+
+end
+

--- a/test/support/config/tasks.rb
+++ b/test/support/config/tasks.rb
@@ -1,0 +1,7 @@
+require 'dk'
+require 'test/support/config/task_defs'
+
+Dk.configure do
+  task 'cli-test-task',  CLITestTask
+  task 'cli-other-task', CLIOtherTask
+end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -1,0 +1,241 @@
+require 'assert'
+require 'dk/cli'
+
+require 'dk/config'
+require 'dk/dk_runner'
+require 'dk/dry_runner'
+require 'dk/task'
+require 'dk/tree_runner'
+require 'dk/version'
+
+class Dk::CLI
+
+  class UnitTests < Assert::Context
+    desc "Dk::CLI"
+    setup do
+      @cli_class = Dk::CLI
+    end
+    subject{ @cli_class }
+
+    should have_imeths :run
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @kernel_spy = KernelSpy.new
+
+      @scmd_test_mode = ENV['SCMD_TEST_MODE']
+      Dk.reset
+      ENV['DK_CONFIG'] = ROOT_PATH.join('test/support/config/tasks.rb')
+      @cli = Dk::CLI.new(@kernel_spy)
+    end
+    teardown do
+      Dk.reset
+      ENV['SCMD_TEST_MODE'] = @scmd_test_mode
+    end
+    subject{ @cli }
+
+    should have_readers :clirb
+    should have_imeths :run
+
+    should "know its clirb" do
+      assert_instance_of Dk::CLIRB, subject.clirb
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run with a configured task name"
+    setup do
+      @runner_init_with = nil
+      @runner_runs  = []
+      Assert.stub(Dk::DkRunner, :new) do |*args|
+        @runner_init_with = args
+
+        runner = Assert.stub_send(Dk::DkRunner, :new, *args)
+        Assert.stub(runner, :run){ |*args| @runner_runs << args }
+        runner
+      end
+      @cli.run('cli-test-task', 'cli-other-task')
+    end
+
+    should "build live runner, not disable scmd and run the named tasks and exit" do
+      assert_equal [Dk.config],     @runner_init_with
+      assert_equal @scmd_test_mode, ENV['SCMD_TEST_MODE']
+
+      assert_equal 2, @runner_runs.size
+      assert_equal [CLITestTask],  @runner_runs.first
+      assert_equal [CLIOtherTask], @runner_runs.last
+
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithDryRunFlagTests < InitTests
+    desc "and run with the --dry-run flag"
+    setup do
+      @runner_init_with = nil
+      @runner_run_with  = nil
+      Assert.stub(Dk::DryRunner, :new) do |*args|
+        @runner_init_with = args
+
+        runner = Assert.stub_send(Dk::DryRunner, :new, *args)
+        Assert.stub(runner, :run){ |*args| @runner_run_with = args }
+        runner
+      end
+      @cli.run('cli-test-task', '--dry-run')
+    end
+
+    should "build dry runner, disable scmd and run the named task and exit" do
+      assert_equal [Dk.config],   @runner_init_with
+      assert_equal '1',           ENV['SCMD_TEST_MODE']
+      assert_equal [CLITestTask], @runner_run_with
+
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithDryTreeFlagTests < InitTests
+    desc "and run with the --tree flag"
+    setup do
+      @runner_init_with = nil
+      @runner_run_with  = nil
+      Assert.stub(Dk::TreeRunner, :new) do |*args|
+        @runner_init_with = args
+
+        runner = Assert.stub_send(Dk::TreeRunner, :new, *args)
+        Assert.stub(runner, :run){ |*args| @runner_run_with = args }
+        runner
+      end
+      @cli.run('cli-test-task', '--tree')
+    end
+
+    should "build tree runner, disable scmd and run the named task and exit" do
+      assert_equal [Dk.config, @kernel_spy], @runner_init_with
+      assert_equal '1',                      ENV['SCMD_TEST_MODE']
+      assert_equal [CLITestTask],            @runner_run_with
+
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithDashTFlagTests < InitTests
+    desc "and run with the -T flag"
+    setup do
+      @cli.run(['-T', '--list-tasks'].sample)
+    end
+
+    should "list out the callable task details and exit" do
+      exp = "TODO: task list here\n"
+      assert_equal exp, @kernel_spy.output
+      assert_equal 0,   @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithHelpFlagTests < InitTests
+    desc "and run with the --help flag"
+    setup do
+      @cli.run('--help')
+    end
+
+    should "print some help info and exit" do
+      exp = "Usage: dk [TASKS] [options]\n\n" \
+            "Tasks:\n" \
+            "TODO: task list here\n\n" \
+            "Options: #{subject.clirb.to_s}"
+      assert_equal exp, @kernel_spy.output
+      assert_equal 0,   @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithVersionFlagTests < InitTests
+    desc "and run with the --version flag"
+    setup do
+      @cli.run('--version')
+    end
+
+    should "print some help info and exit" do
+      exp = "#{Dk::VERSION}\n"
+      assert_equal exp, @kernel_spy.output
+      assert_equal 0,   @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithUnknownTaskTests < InitTests
+    desc "and run with an unknown task"
+    setup do
+      @task_name = Factory.string
+      @cli.run(@task_name)
+    end
+
+    should "output to the user that the task is not known and exit" do
+      exp = "No task named #{@task_name.inspect}"
+      assert_includes exp, @kernel_spy.output
+      assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithInvalidOptionTests < InitTests
+    desc "and run with an invalid option"
+    setup do
+      @option_name = "--#{Factory.string}"
+      @cli.run(@option_name)
+    end
+
+    should "output to the user that the option is invalid and exit" do
+      exp = "invalid option: #{@option_name}"
+      assert_includes exp, @kernel_spy.output
+      assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithAnErrorTests < InitTests
+    desc "and run with an error"
+    setup do
+      Assert.stub(subject.clirb, :parse!){ raise StandardError, 'test' }
+      @cli.run
+    end
+
+    should "output the error and exit" do
+      exp = "StandardError: test\n"
+      assert_includes exp, @kernel_spy.output
+      assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class KernelSpy
+    def initialize
+      @output = StringIO.new
+      @exit_statuses = []
+    end
+
+    def output
+      @output.rewind
+      @output.read
+    end
+
+    def puts(message)
+      @output.puts(message)
+    end
+
+    def exit(code)
+      @exit_statuses << code
+    end
+
+    def exit_status
+      @exit_statuses.first
+    end
+  end
+
+end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -116,7 +116,7 @@ class Dk::Config
       task_class = Class.new{ include Dk::Task }
       subject.task(task_name, task_class)
 
-      assert_equal task_class, subject.tasks[task_name]
+      assert_equal task_class, subject.task(task_name)
     end
 
     should "complain when adding a callable task that isn't a Dk::Task" do
@@ -125,6 +125,12 @@ class Dk::Config
       end
       assert_raises(ArgumentError) do
         subject.task(Factory.string, Class.new)
+      end
+    end
+
+    should "complain when looking up a named task that hasn't been configured" do
+      assert_raises(UnknownTaskError) do
+        subject.task(Factory.string)
       end
     end
 

--- a/test/unit/dk_tests.rb
+++ b/test/unit/dk_tests.rb
@@ -12,7 +12,7 @@ module Dk
     end
     subject{ @dk_module }
 
-    should have_imeths :config, :configure, :init
+    should have_imeths :config, :configure, :init, :reset
 
     should "know its config" do
       assert_instance_of Config, subject.config
@@ -33,6 +33,15 @@ module Dk
 
       subject.init
       assert_true config_init_called
+    end
+
+    should "reset itself by rewriting the config with a new instance" do
+      config_obj_id = subject.config.object_id
+      subject.init
+      assert_equal config_obj_id, subject.config.object_id
+
+      subject.reset
+      assert_not_equal config_obj_id, subject.config.object_id
     end
 
   end

--- a/test/unit/tree_runner_tests.rb
+++ b/test/unit/tree_runner_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'dk/tree_runner'
 
+require 'stringio'
 require 'dk/config'
 require 'dk/dry_runner'
 require 'dk/has_the_runs'
@@ -30,8 +31,9 @@ class Dk::TreeRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
+      @kernal_puts_output = ""
       config = Dk::Config.new
-      @runner = @runner_class.new(config)
+      @runner = @runner_class.new(config, StringIO.new(@kernal_puts_output))
     end
     subject{ @runner }
 
@@ -82,6 +84,11 @@ class Dk::TreeRunner
       sub_sub_task_run = sub_task_run.runs.first
       assert_equal TestTask::SubSubTask,             sub_sub_task_run.task_class
       assert_equal subject.sub_task.sub_task_params, sub_sub_task_run.params
+    end
+
+    should "output some info describing the tree of tasks that were run" do
+      exp = "TODO: task tree output goes here\n"
+      assert_equal exp, @kernal_puts_output
     end
 
   end


### PR DESCRIPTION
This is the basic CLI for running callbable tasks.  You pass it
a list of task names and it runs each named task.  You can pass
the `--dry-run` option to use the DryRunner and the `--tree` opt
to use the TreeRunner.  Pass `-T` to list out the callable tasks
(like cap/rake).

In a future effort, some of the UX will be polished but I want
to wait and test in real-world scenarios with real-world tasks.

A few notes:
- I added the `reset` API to the main module - this is mostly
  to help with testing the CLI
- The Config now raises an exception when trying to lookup an
  unknown task - this is so the CLI can rescue this exception
  and handle it in a nice way
- The Config `task` DSL method now just returns the named task
  if no task class is specified.  The CLI uses this method to
  lookup the tasks.
- The TreeRunner now expects the Kernel to be passed in on init
  so it can `puts` the task tree output.  I need to use `puts`
  and not the logger b/c the logger has been disabled in the tree
  runner.

```
$ dk --help
Usage: dk [TASKS] [options]

Tasks:
TODO: task list here

Options: 
    -T, --[no-]list-tasks            list all tasks available to run
    -d, --[no-]dry-run               run the tasks without executing any local/remote cmds
    -t, --[no-]tree                  print out the tree of tasks/sub-tasks that would be run
        --version
        --help
```

@jcredding ready for review.
