### PR TITLE
add testing helper methods for Task ssh hosts and callbacks

### DIFF
--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -36,6 +36,10 @@ module Dk
         end
       end
 
+      def dk_dsl_ssh_hosts
+        @dk_dsl_ssh_hosts ||= self.instance_eval(&self.class.ssh_hosts)
+      end
+
       def ==(other_task)
         self.class == other_task.class
       end
@@ -104,12 +108,8 @@ module Dk
       def dk_lookup_ssh_hosts(opts_hosts)
         ssh_hosts[opts_hosts] ||
         opts_hosts ||
-        ssh_hosts[dk_dsl_ssh_hosts] ||
-        dk_dsl_ssh_hosts
-      end
-
-      def dk_dsl_ssh_hosts
-        @dk_dsl_ssh_hosts ||= self.instance_eval(&self.class.ssh_hosts)
+        ssh_hosts[self.dk_dsl_ssh_hosts] ||
+        self.dk_dsl_ssh_hosts
       end
 
       def dk_lookup_ssh_args(opts_args)
@@ -135,6 +135,9 @@ module Dk
 
       def before_callbacks; @before_callbacks ||= []; end
       def after_callbacks;  @after_callbacks  ||= []; end
+
+      def before_callback_task_classes; self.before_callbacks.map(&:task_class) end
+      def after_callback_task_classes;  self.after_callbacks.map(&:task_class)  end
 
       def before(task_class, params = nil)
         self.before_callbacks << Callback.new(task_class, params)


### PR DESCRIPTION
These allow the user to test without having to know details about
how the task implements its internal logic.  This adds class
methods for easily getting the callback task classes that were
configured.  This also makes the `dk_dsl_ssh_hosts` method public
so you can use it to test the ssh hosts that were configured.
This needs to be an instance method as you can configure procs
that are eval'd against the task instance and use instance data
to determine the hosts.

This all came up while testing tasks in a coming Dk::ABDeploy
gem.

@jcredding ready for review.
