### PR TITLE
add `ssh_cmd_str` Task helper method

### DIFF
--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -4,6 +4,11 @@ require 'dk/local'
 module Dk; end
 module Dk::Remote
 
+  def self.ssh_cmd_str(cmd_str, host, args, host_args)
+    val = "\"#{cmd_str.gsub(/\s+/, ' ')}\"".gsub("\\", "\\\\\\").gsub('"', '\"')
+    "ssh #{args} #{host_args[host.to_s]} #{host} -- \"sh -c #{val}\""
+  end
+
   class BaseCmd
 
     attr_reader :hosts, :ssh_args, :host_ssh_args, :cmd_str, :local_cmds
@@ -52,8 +57,7 @@ module Dk::Remote
 
     # escape everything properly; run in sh to ensure full profile is loaded
     def ssh_cmd_str(cmd_str, host, args, host_args)
-      val = "\"#{cmd_str.gsub(/\s+/, ' ')}\"".gsub("\\", "\\\\\\").gsub('"', '\"')
-      "ssh #{args} #{host_args[host.to_s]} #{host} -- \"sh -c #{val}\""
+      Dk::Remote.ssh_cmd_str(cmd_str, host, args, host_args)
     end
 
     def build_output_lines(host, local_cmd_output_lines)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -1,4 +1,5 @@
 require 'much-plugin'
+require 'dk/remote'
 
 module Dk
 
@@ -88,6 +89,16 @@ module Dk
         @dk_runner.ssh_hosts(group_name, *values)
       end
 
+      def ssh_cmd_str(cmd_str, opts = nil)
+        opts ||= {}
+        Remote.ssh_cmd_str(
+          cmd_str,
+          opts[:host].to_s,
+          dk_lookup_ssh_args(opts[:ssh_args]),
+          dk_lookup_host_ssh_args(opts[:host_ssh_args])
+        )
+      end
+
       def halt
         throw :halt
       end
@@ -101,7 +112,7 @@ module Dk
         opts.merge({
           :hosts         => dk_lookup_ssh_hosts(opts[:hosts]),
           :ssh_args      => dk_lookup_ssh_args(opts[:ssh_args]),
-          :host_ssh_args => dk_lookup_host_ssh_args(opts[:host_ssh_args]),
+          :host_ssh_args => dk_lookup_host_ssh_args(opts[:host_ssh_args])
         })
       end
 


### PR DESCRIPTION
This method is to help running local ssh cmds against a single
host.  It uses all the same remote ssh cmd logic to build the
local cmd string and lookup/handle any ssh args.

To accomplish this I added a `ssh_cmd_str` singleton method to
`Remote`.  This commonizes the ssh cmd building logic and allows
me to call for the ssh cmd str from a task instance.  The task
instance uses the same logic as the `ssh` helpers to lookup ssh
args so all ssh configs are honored.

Note: this cleans up the tests a bit as I noticed some things
while writing the tests for this effort.

@jcredding ready for review.  I found I needed this helper while working on dk-abdeploy, FYI.
