### PR TITLE
change Config to store task callbacks

### DIFF
--- a/lib/dk/config_runner.rb
+++ b/lib/dk/config_runner.rb
@@ -7,11 +7,15 @@ module Dk
     def initialize(config, opts = nil)
       opts ||= {}
       super({
-        :params        => config.params,
-        :ssh_hosts     => config.ssh_hosts,
-        :ssh_args      => config.ssh_args,
-        :host_ssh_args => config.host_ssh_args,
-        :logger        => opts[:logger] || config.dk_logger
+        :params                   => config.params,
+        :before_callbacks         => config.before_callbacks,
+        :prepend_before_callbacks => config.prepend_before_callbacks,
+        :after_callbacks          => config.after_callbacks,
+        :prepend_after_callbacks  => config.prepend_after_callbacks,
+        :ssh_hosts                => config.ssh_hosts,
+        :ssh_args                 => config.ssh_args,
+        :host_ssh_args            => config.host_ssh_args,
+        :logger                   => opts[:logger] || config.dk_logger
       })
     end
 

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -18,11 +18,23 @@ module Dk
       @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
       @params.merge!(dk_normalize_params(opts[:params]))
 
+      d = Config::DEFAULT_CALLBACKS
+      @task_callbacks = {
+        'before'         => opts[:before_callbacks]         || d.dup,
+        'prepend_before' => opts[:prepend_before_callbacks] || d.dup,
+        'after'          => opts[:after_callbacks]          || d.dup,
+        'prepend_after'  => opts[:prepend_after_callbacks]  || d.dup
+      }
+
       @ssh_hosts     = opts[:ssh_hosts]     || Config::DEFAULT_SSH_HOSTS.dup
       @ssh_args      = opts[:ssh_args]      || Config::DEFAULT_SSH_ARGS.dup
       @host_ssh_args = opts[:host_ssh_args] || Config::DEFAULT_HOST_SSH_ARGS.dup
 
       @logger = opts[:logger] || NullLogger.new
+    end
+
+    def task_callbacks(named, task_class)
+      @task_callbacks[named][task_class] || []
     end
 
     # called by CLI on top-level tasks

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -32,9 +32,10 @@ module Dk
       end
 
       def dk_run_callbacks(named)
-        (self.class.send("#{named}_callbacks") || []).each do |callback|
-          run_task(callback.task_class, callback.params)
-        end
+        callbacks  = @dk_runner.task_callbacks("prepend_#{named}", self.class)
+        callbacks += (self.class.send("#{named}_callbacks") || [])
+        callbacks += @dk_runner.task_callbacks(named, self.class)
+        callbacks.each{ |c| run_task(c.task_class, c.params) }
       end
 
       def dk_dsl_ssh_hosts
@@ -149,8 +150,8 @@ module Dk
       def before_callbacks; @before_callbacks ||= []; end
       def after_callbacks;  @after_callbacks  ||= []; end
 
-      def before_callback_task_classes; self.before_callbacks.map(&:task_class) end
-      def after_callback_task_classes;  self.after_callbacks.map(&:task_class)  end
+      def before_callback_task_classes; self.before_callbacks.map(&:task_class); end
+      def after_callback_task_classes;  self.after_callbacks.map(&:task_class);  end
 
       def before(task_class, params = nil)
         self.before_callbacks << Callback.new(task_class, params)

--- a/test/unit/config_runner_tests.rb
+++ b/test/unit/config_runner_tests.rb
@@ -22,7 +22,16 @@ class Dk::ConfigRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
+      @name       = ['before', 'after'].sample
+      @task_class = Factory.string
+      @callbacks  = Factory.integer(3).times.map{ Factory.string }
+
       @config = Dk::Config.new
+
+      @callbacks.each do |callback_task_class|
+        @config.send(@name, @task_class, callback_task_class)
+        @config.send("prepend_#{@name}", @task_class, callback_task_class)
+      end
     end
 
     should "initialize using the config's values" do
@@ -33,6 +42,11 @@ class Dk::ConfigRunner
       assert_equal @config.ssh_args,      runner.ssh_args
       assert_equal @config.host_ssh_args, runner.host_ssh_args
       assert_equal @config.dk_logger,     runner.logger
+
+      exp = @callbacks
+      assert_equal exp, runner.task_callbacks(@name, @task_class).map(&:task_class)
+      exp = @callbacks.reverse
+      assert_equal exp, runner.task_callbacks("prepend_#{@name}", @task_class).map(&:task_class)
     end
 
     should "honor any custom logger option" do

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -154,7 +154,27 @@ module Dk::Task
       # build a base runner and task manually so the callback tasks actually
       # run (b/c the test runner doesn't run callbacks)
       @runner = Dk::Runner.new({
-        :params => { 'call_orders' => @call_orders }
+        :params                   => { 'call_orders' => @call_orders },
+        :before_callbacks         => {
+          CallbacksTask => [
+            Callback.new(CallbackTask, 'callback' => 'runner_before')
+          ]
+        },
+        :prepend_before_callbacks => {
+          CallbacksTask => [
+            Callback.new(CallbackTask, 'callback' => 'runner_prepend_before')
+          ]
+        },
+        :after_callbacks          => {
+          CallbacksTask => [
+            Callback.new(CallbackTask, 'callback' => 'runner_after')
+          ]
+        },
+        :prepend_after_callbacks  => {
+          CallbacksTask => [
+            Callback.new(CallbackTask, 'callback' => 'runner_prepend_after')
+          ]
+        }
       })
 
       # use this CallbacksTask that has a bunch of callbacks configured so we
@@ -167,13 +187,17 @@ module Dk::Task
     end
 
     should "call `run!` and run any callback tasks" do
-      assert_equal 1,  @call_orders.prepend_before_call_order
-      assert_equal 2,  @call_orders.first_before_call_order
-      assert_equal 3,  @call_orders.second_before_call_order
-      assert_equal 4,  @call_orders.run_call_order
-      assert_equal 5,  @call_orders.prepend_after_call_order
-      assert_equal 6,  @call_orders.first_after_call_order
-      assert_equal 7,  @call_orders.second_after_call_order
+      assert_equal  1, @call_orders.runner_prepend_before_call_order
+      assert_equal  2, @call_orders.prepend_before_call_order
+      assert_equal  3, @call_orders.first_before_call_order
+      assert_equal  4, @call_orders.second_before_call_order
+      assert_equal  5, @call_orders.runner_before_call_order
+      assert_equal  6, @call_orders.run_call_order
+      assert_equal  7, @call_orders.runner_prepend_after_call_order
+      assert_equal  8, @call_orders.prepend_after_call_order
+      assert_equal  9, @call_orders.first_after_call_order
+      assert_equal 10, @call_orders.second_after_call_order
+      assert_equal 11, @call_orders.runner_after_call_order
     end
 
   end
@@ -618,16 +642,24 @@ module Dk::Task
   class CallOrders
     attr_reader :first_before_call_order, :second_before_call_order
     attr_reader :prepend_before_call_order
+    attr_reader :runner_prepend_before_call_order
+    attr_reader :runner_before_call_order
     attr_reader :first_after_call_order, :second_after_call_order
     attr_reader :prepend_after_call_order
+    attr_reader :runner_prepend_after_call_order
+    attr_reader :runner_after_call_order
     attr_reader :run_call_order
 
-    def first_before;   @first_before_call_order   = next_call_order; end
-    def second_before;  @second_before_call_order  = next_call_order; end
-    def prepend_before; @prepend_before_call_order = next_call_order; end
-    def first_after;    @first_after_call_order    = next_call_order; end
-    def second_after;   @second_after_call_order   = next_call_order; end
-    def prepend_after;  @prepend_after_call_order  = next_call_order; end
+    def first_before;          @first_before_call_order          = next_call_order; end
+    def second_before;         @second_before_call_order         = next_call_order; end
+    def prepend_before;        @prepend_before_call_order        = next_call_order; end
+    def runner_prepend_before; @runner_prepend_before_call_order = next_call_order; end
+    def runner_before;         @runner_before_call_order         = next_call_order; end
+    def first_after;           @first_after_call_order           = next_call_order; end
+    def second_after;          @second_after_call_order          = next_call_order; end
+    def prepend_after;         @prepend_after_call_order         = next_call_order; end
+    def runner_prepend_after;  @runner_prepend_after_call_order  = next_call_order; end
+    def runner_after;          @runner_after_call_order          = next_call_order; end
 
     def run; @run_call_order = next_call_order; end
 


### PR DESCRIPTION
This changes the Config class to actual store callback config info
instead of blindly calling the Task DSL.  The idea is that config
settings should be confined to just the config instance.  The prev
implementation would take config settings and apply them to the
task singletons (changing global data).  This is not friendly as
the user is making instance changes that are actually making
global changes.  If the user intends to add a global callback,
they can do that via the normal task DSL api.

This switches to storing the settings on the config instance and
then making the task aware of these when running its callbacks.
I chose to store 4 callback collections on the config b/c I need
to differentiate between normal and prepend callbacks so that the
prepend can be applied before the regular callbacks and the regular
global callbacks.

Note: outside of the global task callbacks, this has no effect
to the overall behavior.

@jcredding ready for review.
