### PR TITLE
add Task DSL method to ensure tasks run only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,25 @@ class MyTask
 end
 ```
 
+#### Ensure Tasks Only Run Once
+
+```ruby
+require 'dk/task'
+
+class MyTask
+  include Dk::Task
+
+  run_only_once true
+
+  def run!
+    # ... do something ...
+  end
+
+end
+```
+
+Use this setting to ensure that a task only runs once no matter how many other tasks or sub-tasks either run it manually or configure it as a callback.  This is useful for "gatekeeper" tasks such as tasks that validate params, etc.  By default, tasks can run multiple times.
+
 #### Testing Tasks
 
 Dk comes with a test runner and some test helpers to assist in unit testing tasks.  The test runner doesn't run any callback tasks and captures spies for the task, cmd and ssh calls it runs.  It also turns off any logging.

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'dk/config'
 require 'dk/has_set_param'
 require 'dk/has_ssh_opts'
@@ -31,6 +32,8 @@ module Dk
       @host_ssh_args = opts[:host_ssh_args] || Config::DEFAULT_HOST_SSH_ARGS.dup
 
       @logger = opts[:logger] || NullLogger.new
+
+      @has_run_task_classes = Set.new
     end
 
     def task_callbacks(named, task_class)
@@ -59,10 +62,17 @@ module Dk
       build_and_run_remote_cmd(cmd_str, opts)
     end
 
+    def has_run_task?(task_class)
+      @has_run_task_classes.include?(task_class)
+    end
+
     private
 
     def build_and_run_task(task_class, params = nil)
-      build_task(task_class, params).tap(&:dk_run)
+      build_task(task_class, params).tap do |task|
+        task.dk_run
+        @has_run_task_classes << task_class
+      end
     end
 
     def build_task(task_class, params = nil)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -23,7 +23,10 @@ module Dk
 
       def dk_run
         self.dk_run_callbacks 'before'
-        catch(:halt){ self.run! }
+        catch(:halt) do
+          halt if self.class.run_only_once && @dk_runner.has_run_task?(self.class)
+          self.run!
+        end
         self.dk_run_callbacks 'after'
       end
 
@@ -172,6 +175,11 @@ module Dk
       def ssh_hosts(value = nil, &block)
         @ssh_hosts = block || proc{ value } if !block.nil? || !value.nil?
         @ssh_hosts || proc{}
+      end
+
+      def run_only_once(value = nil)
+        @run_only_once = !!value if !value.nil?
+        @run_only_once
       end
 
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -44,6 +44,7 @@ class Dk::Runner
     should have_imeths :run, :run_task
     should have_imeths :log_info, :log_debug, :log_error
     should have_imeths :cmd, :ssh
+    should have_imeths :has_run_task?
 
     should "know its attrs" do
       assert_equal @args[:params], subject.params
@@ -134,6 +135,17 @@ class Dk::Runner
 
       subject.log_error msg
       assert_equal [msg], logger_error_called_with
+    end
+
+    should "know if it has run a task or not" do
+      assert_false subject.has_run_task?(TestTask)
+      subject.run(TestTask)
+      assert_true subject.has_run_task?(TestTask)
+
+      task_class = Class.new{ include Dk::Task; def run!; end }
+      assert_false subject.has_run_task?(task_class)
+      subject.run_task(task_class)
+      assert_true subject.has_run_task?(task_class)
     end
 
   end


### PR DESCRIPTION
This is useful for "gatekeeper" tasks. For example, many different
tasks could setup a "Validate" task as a before callback.  However
the task only needs to run once, even if multiple tasks that are
being run set it up as a before callback.

This updates the runner to track a Set of task classes that have
run.  The task now checks whether it is configured to only run
once and, if so, halts if it has already run.  All callbacks are
always run.

@jcredding ready for review.
