### PR TITLE
Pass stdin to local and remote cmds

### DIFF
--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -65,6 +65,11 @@ module Dk::Local
       @cmd_opts = opts
     end
 
+    def run_input
+      return nil unless self.run_called?
+      self.run_calls.first.input
+    end
+
     def stdout=(value);     @scmd.stdout     = value; end
     def stderr=(value);     @scmd.stderr     = value; end
     def exitstatus=(value); @scmd.exitstatus = value; end

--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -88,6 +88,11 @@ module Dk::Remote
       @first_local_cmd_spy = @local_cmds[@hosts.first]
     end
 
+    def run_input
+      return nil unless self.run_called?
+      self.run_calls.first.input
+    end
+
     # just set the first local cmd, this will have an overall effect
     def stdout=(value);     @first_local_cmd_spy.stdout     = value; end
     def stderr=(value);     @first_local_cmd_spy.stderr     = value; end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -54,12 +54,12 @@ module Dk
     def log_debug(msg); self.logger.debug(msg); end # TODO: style up
     def log_error(msg); self.logger.error(msg); end # TODO: style up
 
-    def cmd(cmd_str, opts)
-      build_and_run_local_cmd(cmd_str, opts)
+    def cmd(cmd_str, input, opts)
+      build_and_run_local_cmd(cmd_str, input, opts)
     end
 
-    def ssh(cmd_str, opts)
-      build_and_run_remote_cmd(cmd_str, opts)
+    def ssh(cmd_str, input, opts)
+      build_and_run_remote_cmd(cmd_str, input, opts)
     end
 
     def has_run_task?(task_class)
@@ -79,8 +79,8 @@ module Dk
       task_class.new(self, params)
     end
 
-    def build_and_run_local_cmd(cmd_str, opts, &block)
-      log_local_cmd(build_local_cmd(cmd_str, opts)){ |cmd| cmd.run }
+    def build_and_run_local_cmd(cmd_str, input, opts)
+      log_local_cmd(build_local_cmd(cmd_str, opts)){ |cmd| cmd.run(input) }
     end
 
     def build_local_cmd(cmd_str, opts)
@@ -96,8 +96,8 @@ module Dk
       cmd
     end
 
-    def build_and_run_remote_cmd(cmd_str, opts, &block)
-      log_remote_cmd(build_remote_cmd(cmd_str, opts)){ |cmd| cmd.run }
+    def build_and_run_remote_cmd(cmd_str, input, opts)
+      log_remote_cmd(build_remote_cmd(cmd_str, opts)){ |cmd| cmd.run(input) }
     end
 
     def build_remote_cmd(cmd_str, opts)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -57,24 +57,28 @@ module Dk
         @dk_runner.run_task(task_class, params)
       end
 
-      def cmd(cmd_str, opts = nil)
-        @dk_runner.cmd(cmd_str, opts)
+      def cmd(cmd_str, *args)
+        opts  = args.last.kind_of?(::Hash) ? args.pop : {}
+        input = args.last
+        @dk_runner.cmd(cmd_str, input, opts)
       end
 
-      def cmd!(cmd_str, opts = nil)
-        cmd = @dk_runner.cmd(cmd_str, opts)
+      def cmd!(cmd_str, *args)
+        cmd = @dk_runner.cmd(cmd_str, *args)
         if !cmd.success?
           raise CmdRunError, "error running `#{cmd.cmd_str}`", caller
         end
         cmd
       end
 
-      def ssh(cmd_str, opts = nil)
-        @dk_runner.ssh(cmd_str, dk_build_ssh_opts(opts))
+      def ssh(cmd_str, *args)
+        opts  = args.last.kind_of?(::Hash) ? args.pop : {}
+        input = args.last
+        @dk_runner.ssh(cmd_str, input, dk_build_ssh_opts(opts))
       end
 
-      def ssh!(cmd_str, opts = nil)
-        cmd = ssh(cmd_str, opts)
+      def ssh!(cmd_str, *args)
+        cmd = ssh(cmd_str, *args)
         if !cmd.success?
           raise SSHRunError, "error running `#{cmd.cmd_str}` over ssh", caller
         end

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -28,13 +28,13 @@ module Dk
     end
 
     # track that a local cmd was run
-    def cmd(cmd_str, opts)
-      super(cmd_str, opts).tap{ |c| self.runs << c }
+    def cmd(cmd_str, input, opts)
+      super(cmd_str, input, opts).tap{ |c| self.runs << c }
     end
 
     # track that a remote cmd was run
-    def ssh(cmd_str, opts)
-      super(cmd_str, opts).tap{ |c| self.runs << c }
+    def ssh(cmd_str, input, opts)
+      super(cmd_str, input, opts).tap{ |c| self.runs << c }
     end
 
     # test task API

--- a/test/unit/local_tests.rb
+++ b/test/unit/local_tests.rb
@@ -120,7 +120,7 @@ module Dk::Local
     end
 
     should have_readers :cmd_opts
-    should have_imeths :stdout=, :stderr=, :exitstatus=
+    should have_imeths :run_input, :stdout=, :stderr=, :exitstatus=
     should have_imeths :run_calls, :run_called?
 
     should "build an scmd spy with the cmd str and any given options" do
@@ -131,6 +131,14 @@ module Dk::Local
       cmd  = @cmd_class.new(@cmd_str, opts)
       assert_equal [@cmd_str, { :env => opts[:env] }], @scmd_spy_new_called_with
       assert_equal opts, cmd.cmd_opts
+    end
+
+    should "know the input it was run with" do
+      input = Factory.string
+
+      assert_nil subject.run_input
+      subject.run(input)
+      assert_equal input, subject.run_input
     end
 
     should "demeter its scmd spy" do

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -224,7 +224,7 @@ module Dk::Remote
     subject{ @cmd }
 
     should have_readers :cmd_opts
-    should have_imeths :stdout=, :stderr=, :exitstatus=
+    should have_imeths :run_input, :stdout=, :stderr=, :exitstatus=
     should have_imeths :run_calls, :run_called?
 
     should "build a local cmd spy for each host with the cmd str, given opts" do
@@ -256,6 +256,14 @@ module Dk::Remote
       )
       exp_opts = { :env => @opts[:env] }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_spy_new_called_with
+    end
+
+    should "know the input it was run with" do
+      input = Factory.string
+
+      assert_nil subject.run_input
+      subject.run(input)
+      assert_equal input, subject.run_input
     end
 
     should "demeter its first local cmd spy" do

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -153,6 +153,7 @@ class Dk::Runner
   class CmdSetupTests < UnitTests
     setup do
       @cmd_str   = Factory.string
+      @cmd_input = Factory.string
       @cmd_opts  = { Factory.string => Factory.string}
 
       @log_out = ""
@@ -182,13 +183,14 @@ class Dk::Runner
     end
 
     should "build, log and run local cmds" do
-      @runner.cmd(@cmd_str, @cmd_opts)
+      @runner.cmd(@cmd_str, @cmd_input, @cmd_opts)
 
       exp = [@cmd_str, @cmd_opts]
       assert_equal exp, @local_cmd_new_called_with
 
       assert_not_nil @local_cmd
       assert_true @local_cmd.run_called?
+      assert_equal @cmd_input, @local_cmd.run_input
 
       assert_equal exp_log_output(@local_cmd), @log_out
     end
@@ -221,13 +223,14 @@ class Dk::Runner
     end
 
     should "build, log and run remote cmds" do
-      @runner.ssh(@cmd_str, @cmd_opts)
+      @runner.ssh(@cmd_str, @cmd_input, @cmd_opts)
 
       exp = [@cmd_str, @cmd_opts]
       assert_equal exp, @remote_cmd_new_called_with
 
       assert_not_nil @remote_cmd
       assert_true @remote_cmd.run_called?
+      assert_equal @cmd_input, @remote_cmd.run_input
 
       assert_equal exp_log_output(@remote_cmd), @log_out
     end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -87,23 +87,27 @@ class Dk::TestRunner
       assert_equal [],                      st.runs
 
       assert_same lc, subject.local_cmd
-      assert_equal subject.local_cmd_str,  lc.cmd_str
-      assert_equal subject.local_cmd_opts, lc.cmd_opts
+      assert_equal subject.local_cmd_str,   lc.cmd_str
+      assert_equal subject.local_cmd_opts,  lc.cmd_opts
+      assert_equal subject.local_cmd_input, lc.run_input
       assert_true lc.run_called?
 
       assert_same lcb, subject.local_cmd_bang
-      assert_equal subject.local_cmd_str,  lcb.cmd_str
-      assert_equal subject.local_cmd_opts, lcb.cmd_opts
+      assert_equal subject.local_cmd_str,   lcb.cmd_str
+      assert_equal subject.local_cmd_opts,  lcb.cmd_opts
+      assert_equal subject.local_cmd_input, lcb.run_input
       assert_true lcb.run_called?
 
       assert_same rc, subject.remote_cmd
-      assert_equal subject.remote_cmd_str,  rc.cmd_str
-      assert_equal subject.remote_cmd_opts, rc.cmd_opts
+      assert_equal subject.remote_cmd_str,   rc.cmd_str
+      assert_equal subject.remote_cmd_opts,  rc.cmd_opts
+      assert_equal subject.remote_cmd_input, rc.run_input
       assert_true rc.run_called?
 
       assert_same rcb, subject.remote_cmd_bang
-      assert_equal subject.remote_cmd_str,  rcb.cmd_str
-      assert_equal subject.remote_cmd_opts, rcb.cmd_opts
+      assert_equal subject.remote_cmd_str,   rcb.cmd_str
+      assert_equal subject.remote_cmd_opts,  rcb.cmd_opts
+      assert_equal subject.remote_cmd_input, rcb.run_input
       assert_true rcb.run_called?
     end
 
@@ -221,12 +225,20 @@ class Dk::TestRunner
       @local_cmd_str ||= Factory.string
     end
 
+    def local_cmd_input
+      @local_cmd_input ||= Factory.string
+    end
+
     def local_cmd_opts
       @local_cmd_opts ||= { Factory.string => Factory.string }
     end
 
     def remote_cmd_str
       @remote_cmd_str ||= Factory.string
+    end
+
+    def remote_cmd_input
+      @remote_cmd_input ||= Factory.string
     end
 
     def remote_cmd_opts
@@ -243,10 +255,10 @@ class Dk::TestRunner
       @run_params = params
 
       @sub_task        = run_task(SubTask, self.sub_task_params)
-      @local_cmd       = cmd(self.local_cmd_str, self.local_cmd_opts)
-      @local_cmd_bang  = cmd!(self.local_cmd_str, self.local_cmd_opts)
-      @remote_cmd      = ssh(self.remote_cmd_str, self.remote_cmd_opts)
-      @remote_cmd_bang = ssh!(self.remote_cmd_str, self.remote_cmd_opts)
+      @local_cmd       = cmd(self.local_cmd_str, self.local_cmd_input, self.local_cmd_opts)
+      @local_cmd_bang  = cmd!(self.local_cmd_str, self.local_cmd_input, self.local_cmd_opts)
+      @remote_cmd      = ssh(self.remote_cmd_str, self.remote_cmd_input, self.remote_cmd_opts)
+      @remote_cmd_bang = ssh!(self.remote_cmd_str, self.remote_cmd_input, self.remote_cmd_opts)
 
       @scmd_test_mode_run_value = ENV['SCMD_TEST_MODE']
     end


### PR DESCRIPTION
This updates the `Task` and `Runner` to allow passing a stdin
value when running local and remote commands. This allows using
stdin without having to embed it into a cmd str.

This updates the `Task` to allow optionally passing a stdin value
to the `cmd` and `ssh` helper methods. The helpers now take a
cmd str, input and opts. The input and opts are both optional and
either one can be provided without the other. This keeps the
interface backwards compatible when running commands without a
stdin value.

This also updates the `Runner` and `TestRunner` to expect a cmd
input value. This is passed to the `Local` or `Remote` commands
`run` methods. The commands were already setup to allow passing
stdin values so this just adds the necessary plumbing.

Finally, this updates the `Local` and `Remote` cmd spies to provide
a helper for testing the stdin value they were run with. This
allows testing that commands are run with an expected stdin.

@kellyredding - Ready for review.
