### PR TITLE
Fix `cmd!` wrong number of args error

### DIFF
--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -5,8 +5,9 @@ module Dk; end
 module Dk::Remote
 
   def self.ssh_cmd_str(cmd_str, host, args, host_args)
+    host_args = host_args[host.to_s] if !host.nil?
     val = "\"#{cmd_str.gsub(/\s+/, ' ')}\"".gsub("\\", "\\\\\\").gsub('"', '\"')
-    "ssh #{args} #{host_args[host.to_s]} #{host} -- \"sh -c #{val}\""
+    "ssh #{args} #{host_args} #{host} -- \"sh -c #{val}\""
   end
 
   class BaseCmd

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -64,7 +64,7 @@ module Dk
       end
 
       def cmd!(cmd_str, *args)
-        cmd = @dk_runner.cmd(cmd_str, *args)
+        cmd = cmd(cmd_str, *args)
         if !cmd.success?
           raise CmdRunError, "error running `#{cmd.cmd_str}`", caller
         end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -261,13 +261,16 @@ module Dk::Task
 
     should "run local cmds, calling to the runner" do
       runner_cmd_called_with = nil
-      Assert.stub(@runner, :cmd){ |*args| runner_cmd_called_with = args }
+      Assert.stub(@runner, :cmd) do |*args|
+        runner_cmd_called_with = args
+        Assert.stub_send(@runner, :cmd, *args)
+      end
 
       cmd_str   = Factory.string
       cmd_input = Factory.string
       cmd_opts  = { Factory.string => Factory.string }
-      subject.instance_eval{ cmd(cmd_str, cmd_input, cmd_opts) }
 
+      subject.instance_eval{ cmd(cmd_str, cmd_input, cmd_opts) }
       exp = [cmd_str, cmd_input, cmd_opts]
       assert_equal exp, runner_cmd_called_with
 
@@ -280,6 +283,22 @@ module Dk::Task
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd(cmd_str, cmd_opts) }
+      exp = [cmd_str, nil, cmd_opts]
+      assert_equal exp, runner_cmd_called_with
+
+      subject.instance_eval{ cmd!(cmd_str, cmd_input, cmd_opts) }
+      exp = [cmd_str, cmd_input, cmd_opts]
+      assert_equal exp, runner_cmd_called_with
+
+      subject.instance_eval{ cmd!(cmd_str) }
+      exp = [cmd_str, nil, {}]
+      assert_equal exp, runner_cmd_called_with
+
+      subject.instance_eval{ cmd!(cmd_str, cmd_input) }
+      exp = [cmd_str, cmd_input, {}]
+      assert_equal exp, runner_cmd_called_with
+
+      subject.instance_eval{ cmd!(cmd_str, cmd_opts) }
       exp = [cmd_str, nil, cmd_opts]
       assert_equal exp, runner_cmd_called_with
     end
@@ -314,7 +333,10 @@ module Dk::Task
 
     should "run ssh cmds, calling to the runner" do
       runner_ssh_called_with = nil
-      Assert.stub(@runner, :ssh){ |*args| runner_ssh_called_with = args }
+      Assert.stub(@runner, :ssh) do |*args|
+        runner_ssh_called_with = args
+        Assert.stub_send(@runner, :ssh, *args)
+      end
 
       cmd_str   = Factory.string
       cmd_input = Factory.string
@@ -324,16 +346,16 @@ module Dk::Task
         :ssh_args      => Factory.string,
         :host_ssh_args => { Factory.string => Factory.string }
       }
-      subject.instance_eval{ ssh(cmd_str, cmd_input, cmd_opts) }
-
-      exp = [cmd_str, cmd_input, cmd_opts]
-      assert_equal exp, runner_ssh_called_with
 
       default_ssh_cmd_opts =  {
         :ssh_args      => "",
         :host_ssh_args => {},
         :hosts         => [nil]
       }
+
+      subject.instance_eval{ ssh(cmd_str, cmd_input, cmd_opts) }
+      exp = [cmd_str, cmd_input, cmd_opts]
+      assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh(cmd_str) }
       exp = [cmd_str, nil, default_ssh_cmd_opts]
@@ -344,6 +366,22 @@ module Dk::Task
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh(cmd_str, cmd_opts) }
+      exp = [cmd_str, nil, cmd_opts]
+      assert_equal exp, runner_ssh_called_with
+
+      subject.instance_eval{ ssh!(cmd_str, cmd_input, cmd_opts) }
+      exp = [cmd_str, cmd_input, cmd_opts]
+      assert_equal exp, runner_ssh_called_with
+
+      subject.instance_eval{ ssh!(cmd_str) }
+      exp = [cmd_str, nil, default_ssh_cmd_opts]
+      assert_equal exp, runner_ssh_called_with
+
+      subject.instance_eval{ ssh!(cmd_str, cmd_input) }
+      exp = [cmd_str, cmd_input, default_ssh_cmd_opts]
+      assert_equal exp, runner_ssh_called_with
+
+      subject.instance_eval{ ssh!(cmd_str, cmd_opts) }
       exp = [cmd_str, nil, cmd_opts]
       assert_equal exp, runner_ssh_called_with
     end


### PR DESCRIPTION
This fixes an error with `cmd!` calling `Runner#cmd` with the wrong
number of args. This is a bug from PR #39 that was missed because
the previous tests didn't test calling `cmd!` with all the possible
args variations. This fixes `cmd!` by switching it to call
`Task#cmd` instead of directly calling `Runner#cmd`. This makes
`cmd!` use the logic to handle optional input and opts args before
`Runner#cmd` is called.

This also updates the task tests to call both `cmd!` and `ssh!`
with all the variations of args that they support. This caused the
previous code to fail as expected and provides us better coverage
going forward.

Finally, this also includes a minor tweak to the
`Remote.ssh_cmd_str` method. If a host isn't provided it won't
try to lookup host ssh args. This was causing strange behavior
that would modify a runner's host ssh args adding an empty string
`""` key that used the default ssh args (also an empty string).
This was because the host ssh args default automatically takes any
key it is passed and sets its value to the default ssh args. This
avoids that happening by chance when a host is not provided for
an ssh command.

@kellyredding - Ready for review.
