### PR TITLE
Rework ssh stubbing to avoid having to know ssh opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,12 +508,35 @@ include Dk::Task::TestHelpers
 test "my task should do something" do
   runner = test_runner(MyTask)
   runner.run
-  runner.runs #=> [TaskRun, Local::CmdSpy, Remote::CmdSpey, ... ]
+  runner.runs #=> [TaskRun, Local::CmdSpy, Remote::CmdSpy, ... ]
 
   # make assertions that the logic you expect to run actually ran
   task = runner.task #=> MyTask instance
 
   # make assertions about your task instance if needed
+end
+```
+
+Dk's test helpers include methods for stubbing cmd and ssh calls.  This allows controlling cmd/ssh behavior such as exit status, stdout and stderr.  If a task expects to use the stdout/stderr or does special handling when a call errors then the stubbing methods can be used for testing.
+
+```ruby
+# in your test file or whatever
+
+include Dk::Task::TestHelpers
+
+test "my task should do something" do
+  runner = test_runner(MyTask)
+  runner.stub_cmd("ls -la") do |spy| # spy is a Local::CmdSpy
+    spy.stdout = "..."
+  end
+  runner.stub_ssh("ls -la") do |spy| # spy is a Remote::CmdSpy
+    spy.exitstatus = 1 # simulare the ssh call failing
+  end
+
+  runner.run
+
+  # make assertions about how your task used the stdout of the
+  # cmd and handled the ssh call that failed
 end
 ```
 

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -54,12 +54,12 @@ module Dk
     def log_debug(msg); self.logger.debug(msg); end # TODO: style up
     def log_error(msg); self.logger.error(msg); end # TODO: style up
 
-    def cmd(cmd_str, input, opts)
-      build_and_run_local_cmd(cmd_str, input, opts)
+    def cmd(cmd_str, input, given_opts)
+      build_and_run_local_cmd(cmd_str, input, given_opts)
     end
 
-    def ssh(cmd_str, input, opts)
-      build_and_run_remote_cmd(cmd_str, input, opts)
+    def ssh(cmd_str, input, given_opts, ssh_opts)
+      build_and_run_remote_cmd(cmd_str, input, given_opts, ssh_opts)
     end
 
     def has_run_task?(task_class)
@@ -79,12 +79,15 @@ module Dk
       task_class.new(self, params)
     end
 
-    def build_and_run_local_cmd(cmd_str, input, opts)
-      log_local_cmd(build_local_cmd(cmd_str, opts)){ |cmd| cmd.run(input) }
+    def build_and_run_local_cmd(cmd_str, input, given_opts)
+      local_cmd = build_local_cmd(cmd_str, input, given_opts)
+      log_local_cmd(local_cmd){ |cmd| cmd.run(input) }
     end
 
-    def build_local_cmd(cmd_str, opts)
-      Local::Cmd.new(cmd_str, opts)
+    # input is needed for the `TestRunner` so it can use it with stubbing
+    # otherwise it is ignored when building a local cmd
+    def build_local_cmd(cmd_str, input, given_opts)
+      Local::Cmd.new(cmd_str, given_opts)
     end
 
     def log_local_cmd(cmd, &block)
@@ -96,12 +99,15 @@ module Dk
       cmd
     end
 
-    def build_and_run_remote_cmd(cmd_str, input, opts)
-      log_remote_cmd(build_remote_cmd(cmd_str, opts)){ |cmd| cmd.run(input) }
+    def build_and_run_remote_cmd(cmd_str, input, given_opts, ssh_opts)
+      remote_cmd = build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
+      log_remote_cmd(remote_cmd){ |cmd| cmd.run(input) }
     end
 
-    def build_remote_cmd(cmd_str, opts)
-      Remote::Cmd.new(cmd_str, opts)
+    # input and given opts are needed for the `TestRunner` so it can use it with
+    # stubbing otherwise they are ignored when building a remote cmd
+    def build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
+      Remote::Cmd.new(cmd_str, ssh_opts)
     end
 
     def log_remote_cmd(cmd, &block)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -58,9 +58,9 @@ module Dk
       end
 
       def cmd(cmd_str, *args)
-        opts  = args.last.kind_of?(::Hash) ? args.pop : {}
-        input = args.last
-        @dk_runner.cmd(cmd_str, input, opts)
+        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+        input      = args.last
+        @dk_runner.cmd(cmd_str, input, given_opts)
       end
 
       def cmd!(cmd_str, *args)
@@ -72,9 +72,9 @@ module Dk
       end
 
       def ssh(cmd_str, *args)
-        opts  = args.last.kind_of?(::Hash) ? args.pop : {}
-        input = args.last
-        @dk_runner.ssh(cmd_str, input, dk_build_ssh_opts(opts))
+        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+        input      = args.last
+        @dk_runner.ssh(cmd_str, input, given_opts, dk_build_ssh_opts(given_opts))
       end
 
       def ssh!(cmd_str, *args)

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,6 +3,20 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.ssh_cmd_opts
+    cmd_opts = { Factory.string => Factory.string }
+    # optionally have these options, this will ensure the default ssh cmd opts
+    # are used if these aren't provided
+    if Factory.boolean
+      cmd_opts.merge!({
+        :hosts         => Factory.hosts,
+        :ssh_args      => Factory.string,
+        :host_ssh_args => { Factory.string => Factory.string }
+      })
+    end
+    cmd_opts
+  end
+
   def self.stdout
     Factory.integer(3).times.map{ Factory.string }.join("\n")
   end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -152,9 +152,9 @@ class Dk::Runner
 
   class CmdSetupTests < UnitTests
     setup do
-      @cmd_str   = Factory.string
-      @cmd_input = Factory.string
-      @cmd_opts  = { Factory.string => Factory.string}
+      @cmd_str        = Factory.string
+      @cmd_input      = Factory.string
+      @cmd_given_opts = { Factory.string => Factory.string }
 
       @log_out = ""
       logger = Logger.new(StringIO.new(@log_out))
@@ -183,9 +183,9 @@ class Dk::Runner
     end
 
     should "build, log and run local cmds" do
-      @runner.cmd(@cmd_str, @cmd_input, @cmd_opts)
+      @runner.cmd(@cmd_str, @cmd_input, @cmd_given_opts)
 
-      exp = [@cmd_str, @cmd_opts]
+      exp = [@cmd_str, @cmd_given_opts]
       assert_equal exp, @local_cmd_new_called_with
 
       assert_not_nil @local_cmd
@@ -208,7 +208,7 @@ class Dk::Runner
   class SSHCmdTests < CmdSetupTests
     desc "running ssh cmds"
     setup do
-      @cmd_opts.merge!(:hosts => Factory.hosts)
+      @cmd_ssh_opts = { :hosts => Factory.hosts }
 
       @remote_cmd = nil
       @remote_cmd_new_called_with = nil
@@ -223,9 +223,9 @@ class Dk::Runner
     end
 
     should "build, log and run remote cmds" do
-      @runner.ssh(@cmd_str, @cmd_input, @cmd_opts)
+      @runner.ssh(@cmd_str, @cmd_input, @cmd_given_opts, @cmd_ssh_opts)
 
-      exp = [@cmd_str, @cmd_opts]
+      exp = [@cmd_str, @cmd_ssh_opts]
       assert_equal exp, @remote_cmd_new_called_with
 
       assert_not_nil @remote_cmd


### PR DESCRIPTION
This reworks the ssh stubbing to avoid having to know the ssh opts
that are built by dk. This makes it so stubbing an ssh call matches
how the `ssh` method is called which greatly simplifies its usage
and avoids having to know how dk builds ssh opts using its
current configuration.

This changes the `ssh` method on `Runner` to now take given opts
and ssh opts. Previously it only took ssh opts. The base `Runner`
only uses the ssh opts as it did previously but by taking the
given opts as well this allows the `TestRunner` to use it for
stubbing. Similarly, the `Runner` how expects input to be passed
when building cmds. The input is not used by the base `Runner` but
will be used by the `TestRunner`. The base `Runner` has to be
updated to keep its interface consistent with what the `TestRunner`
needs.

Now that the `TestRunner` is passed the input, given opts and ssh
opts when building cmds they can be used with the stubbing. Stubs
are now keyed using the cmd str, input and given opts. Using the
given opts allows the opts that are used to call `ssh` can be used
when stubbing `ssh`. When building the cmd spy though the cmd str
and ssh opts are used as they previously were. This also changes
the stub methods to use the same interface as the `ssh` and `cmd`
methods where they will take both an input and opts but both are
optional. All of these changes allow stubbing cmds with the same
interface that they are called.

This also modifies the `TestRunner` to lazily eval its blocks.
Now they aren't called until the `cmd` or `ssh` methods are called
when a task is run. This doesn't change a lot of the behavior
except that the block is not run immediately so its logic is not
immediately available. This is more consistent with assert stubbing
though so it provides a more consistent experience.

Finally, this updates the `cmd` and `ssh` methods on `Task` to
default their opts the same way as the stubs. This fixes a bug
where stubs were not correctly matching because they stubs used
`nil` for opts when none were passed but the `Task` was using
`{}`. This lines them both up to use `nil` as the default if no
opts are passed which ensures stubs match as expected.

@kellyredding - Ready for review.
