### PR TITLE
add helper methods to add task callbacks from tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Dk.configure do
 end
 ```
 
-Each callback can be optionally configured with a set of params.  This can be especially useful when you want to control the order 3rd-party tasks are run in.
+Each callback can be optionally configured with a set of params.  Callbacks can either be appended or prepended (this can be especially useful when you want to control the order 3rd-party tasks are run in).
 
 The callback tasks will be run in the order they are added before/after the `run!` method of the task they are added to.  The [`halt` task helper](https://github.com/redding/dk#halt) does not stop these callbacks from running.
 
@@ -252,6 +252,28 @@ Use the `param` helper to access named params that the task was run with.  Param
 Use the `set_param` method to set new global param values like you would on the main config.  Any subsequent tasks that are run will have these param values available to them.
 
 Use the `param?` method to check whether a specific param has been set.  Prefer this over `params.key?` as the task params have special logic for interacting with any runner params that makes the traditional `key?` method unreliable.
+
+##### `before`, `prepend_before`, `after`, `prepend_after`
+
+[Like in the Config](https://github.com/redding/dk#before-prepend_before-after-prepend_after), you can add tasks as callbacks on other tasks using these helper methods:
+
+```ruby
+require 'dk/task'
+
+class MyTask
+  include Dk::Task
+
+  def run!
+    before         SomeTask, MyBeforeTask
+    prepend_before SomeTask, MyOtherBeforeTask, 'some_param' => 'some_value'
+    after          SomeTask, MyAfterTask,       'some_param' => 'some_value'
+    prepend_after  SomeTask, MyOtherAfterTask
+  end
+
+end
+```
+
+Each callback can be optionally configured with a set of params.  Callbacks can either be appended or prepended (this can be especially useful when you want to control the order 3rd-party tasks are run in).  Once a callback is added, it works just as it would if added via the Config.
 
 ##### `ssh_hosts`
 

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -40,6 +40,17 @@ module Dk
       @task_callbacks[named][task_class] || []
     end
 
+    def task_callback_task_classes(named, task_class)
+      task_callbacks(named, task_class).map(&:task_class)
+    end
+
+    def add_task_callback(named, subject_task_class, callback_task_class, params)
+      @task_callbacks[named][subject_task_class] << Task::Callback.new(
+        callback_task_class,
+        params
+      )
+    end
+
     # called by CLI on top-level tasks
     def run(task_class, params = nil)
       build_and_run_task(task_class, params)

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -97,6 +97,22 @@ module Dk
         @dk_params.key?(key) || @dk_runner.params.key?(key)
       end
 
+      def before(subject, callback, params = nil)
+        @dk_runner.add_task_callback('before', subject, callback, params)
+      end
+
+      def prepend_before(subject, callback, params = nil)
+        @dk_runner.add_task_callback('prepend_before', subject, callback, params)
+      end
+
+      def after(subject, callback, params = nil)
+        @dk_runner.add_task_callback('after', subject, callback, params)
+      end
+
+      def prepend_after(subject, callback, params = nil)
+        @dk_runner.add_task_callback('prepend_after', subject, callback, params)
+      end
+
       def ssh_hosts(group_name = nil, *values)
         @dk_runner.ssh_hosts(group_name, *values)
       end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -40,7 +40,8 @@ class Dk::Runner
     subject{ @runner }
 
     should have_readers :params, :logger
-    should have_imeths :task_callbacks
+    should have_imeths :task_callbacks, :task_callback_task_classes
+    should have_imeths :add_task_callback
     should have_imeths :run, :run_task
     should have_imeths :log_info, :log_debug, :log_error
     should have_imeths :cmd, :ssh
@@ -93,6 +94,24 @@ class Dk::Runner
       runner = @runner_class.new("#{name}_callbacks".to_sym => { task_class => callbacks })
 
       assert_equal callbacks, runner.task_callbacks(name, task_class)
+
+      exp = callbacks.map(&:task_class)
+      assert_equal exp, runner.task_callback_task_classes(name, task_class)
+    end
+
+    should "add task callbacks by name and task class" do
+      name = ['before', 'prepend_before', 'after', 'prepend_after'].sample
+
+      subject         = Factory.string
+      callback        = Factory.string
+      callback_params = { Factory.string => Factory.string }
+
+      runner = @runner_class.new
+      runner.add_task_callback(name, subject, callback, callback_params)
+
+      exp = [Dk::Task::Callback.new(callback, callback_params)]
+      assert_equal exp,        runner.task_callbacks(name, subject)
+      assert_equal [callback], runner.task_callback_task_classes(name, subject)
     end
 
     should "build and run a given task class" do

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -637,6 +637,46 @@ module Dk::Task
 
   end
 
+  class CallbackPrivateHelpersTests < InitTests
+
+    should "append callbacks" do
+      subj   = Factory.string
+      cb     = Factory.string
+      params = Factory.string
+
+      @runner.add_task_callback('before', Factory.string, Factory.string, {})
+      subject.instance_eval{ before(subj, cb, params) }
+      callback = @runner.task_callbacks('before', subj).last
+      assert_equal cb,     callback.task_class
+      assert_equal params, callback.params
+
+      @runner.add_task_callback('after', Factory.string, Factory.string, {})
+      subject.instance_eval{ after(subj, cb, params) }
+      callback = @runner.task_callbacks('after', subj).last
+      assert_equal cb,     callback.task_class
+      assert_equal params, callback.params
+    end
+
+    should "prepend callbacks" do
+      subj   = Factory.string
+      cb     = Factory.string
+      params = Factory.string
+
+      @runner.add_task_callback('prepend_before', Factory.string, Factory.string, {})
+      subject.instance_eval{ prepend_before(subj, cb, params) }
+      callback = @runner.task_callbacks('prepend_before', subj).first
+      assert_equal cb,     callback.task_class
+      assert_equal params, callback.params
+
+      @runner.add_task_callback('prepend_after', Factory.string, Factory.string, {})
+      subject.instance_eval{ prepend_after(subj, cb, params) }
+      callback = @runner.task_callbacks('prepend_after', subj).first
+      assert_equal cb,     callback.task_class
+      assert_equal params, callback.params
+    end
+
+  end
+
   class SSHHostsPrivateHelpersTests < InitTests
 
     should "know and set its runner's ssh hosts" do


### PR DESCRIPTION
The goal here is to have one task add a callback on another class
on the fly.  This allows for dynamic runtime callback manipulation
and makes task callbacks even more flexible.

@jcredding ready for review.
