### PR TITLE
implement listing tasks w/ descs with CLI --help and -T options

### DIFF
--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -66,12 +66,16 @@ module Dk
     def help
       "Usage: dk [TASKS] [options]\n\n" \
       "Tasks:\n" \
-      "#{task_list}\n\n" \
+      "#{task_list('    ')}\n\n" \
       "Options: #{@clirb}"
     end
 
-    def task_list
-      "TODO: task list here"
+    def task_list(prefix = '')
+      max_name_width = @config.tasks.keys.map(&:size).max
+      items = @config.tasks.map do |(name, task_class)|
+        "#{prefix}#{name.ljust(max_name_width)} # #{task_class.description}"
+      end
+      items.sort.join("\n")
     end
 
     def config_path

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -131,7 +131,12 @@ class Dk::CLI
     end
 
     should "list out the callable task details and exit" do
-      exp = "TODO: task list here\n"
+      max   = Dk.config.tasks.keys.map(&:size).max
+      tasks = Dk.config.tasks.map do |(name, task_class)|
+        "#{name.ljust(max)} # #{task_class.description}"
+      end
+
+      exp = "#{tasks.sort.join("\n")}\n"
       assert_equal exp, @kernel_spy.output
       assert_equal 0,   @kernel_spy.exit_status
     end
@@ -145,9 +150,14 @@ class Dk::CLI
     end
 
     should "print some help info and exit" do
+      max   = Dk.config.tasks.keys.map(&:size).max
+      tasks = Dk.config.tasks.map do |(name, task_class)|
+        "    #{name.ljust(max)} # #{task_class.description}"
+      end
+
       exp = "Usage: dk [TASKS] [options]\n\n" \
             "Tasks:\n" \
-            "TODO: task list here\n\n" \
+            "#{tasks.sort.join("\n")}\n\n" \
             "Options: #{subject.clirb.to_s}"
       assert_equal exp, @kernel_spy.output
       assert_equal 0,   @kernel_spy.exit_status


### PR DESCRIPTION
This lists out the names in one column and their descriptions in
a second column.  I chose to prefix the list like the CLI options
output in the --help output.

![imageorelh](https://cloud.githubusercontent.com/assets/82110/17392198/5e406cae-59e1-11e6-99f1-e2dcb1468480.jpg)

![imagelua1g](https://cloud.githubusercontent.com/assets/82110/17392210/745e7986-59e1-11e6-92e6-8819cfa7b188.jpg)

@jcredding ready for review.
