### PR TITLE
add `--verbose` CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ $ dk --help
 Usage: dk [TASKS] [options]
 
 Tasks:
-my-other-task # my other task that does something great
-my-task       # my task that does something great
+    my-other-task # my other task that does something great
+    my-task       # my task that does something great
 
 Options:
     -T, --[no-]list-tasks            list all tasks available to run
     -d, --[no-]dry-run               run the tasks without executing any local/remote cmds
     -t, --[no-]tree                  print out the tree of tasks/sub-tasks that would be run
+    -v, --[no-]verbose               run tasks showing verbose (ie debug log level) details
         --version
         --help
 ```
@@ -85,6 +86,10 @@ This option runs the tasks like the live runner does and disables all system com
 TODO: show task tree output example
 
 Use this to show the user all the tasks/sub-tasks that are run and which parent tasks are running them.
+
+##### `--verbose` option
+
+This option runs tasks showing more verbose output/details (ie it sets the logger's stdout log level to 'debug').  All Task `log_debug` messages will be shown on stdout with this option.  This option also makes the stdout and file logs identical.
 
 ### Config
 

--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -29,6 +29,7 @@ module Dk
         }
         option 'dry-run', 'run the tasks without executing any local/remote cmds'
         option 'tree',    'print out the tree of tasks/sub-tasks that would be run'
+        option 'verbose', 'run tasks showing verbose (ie debug log level) details'
       end
     end
 
@@ -59,7 +60,9 @@ module Dk
       @clirb.parse!(args)
       raise ShowTaskList if @clirb.opts['list-tasks']
 
-      runner = get_runner(@clirb.opts)
+      @config.stdout_log_level('debug') if @clirb.opts['verbose']
+
+      runner = get_runner(@config, @clirb.opts)
       @clirb.args.each{ |task_name| runner.run(@config.task(task_name)) }
     end
 
@@ -82,13 +85,13 @@ module Dk
       File.expand_path(ENV['DK_CONFIG'] || DEFAULT_CONFIG_PATH, ENV['PWD'])
     end
 
-    def get_runner(opts)
+    def get_runner(config, opts)
       if opts['dry-run'] || opts['tree']
         ENV['SCMD_TEST_MODE'] = '1' # disable all local/remote cmds
       end
-      return Dk::DryRunner.new(@config) if opts['dry-run']
-      return Dk::TreeRunner.new(@config, @kernel) if opts['tree']
-      Dk::DkRunner.new(@config)
+      return Dk::DryRunner.new(config) if opts['dry-run']
+      return Dk::TreeRunner.new(config, @kernel) if opts['tree']
+      Dk::DkRunner.new(config)
     end
 
     ShowTaskList = Class.new(RuntimeError)

--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -24,9 +24,8 @@ module Dk
     DEFAULT_TASKS            = Hash.new{ |h, k| raise UnknownTaskError.new(k) }.freeze
     DEFAULT_LOG_PATTERN      = "%m\n".freeze
     DEFAULT_LOG_FILE_PATTERN = '[%d %-5l] : %m\n'.freeze
-
-    STDOUT_LOG_LEVEL = 'info'.freeze
-    FILE_LOG_LEVEL   = 'debug'.freeze
+    DEFAULT_STDOUT_LOG_LEVEL = 'info'.freeze
+    FILE_LOG_LEVEL           = 'debug'.freeze
 
     attr_reader :init_procs, :params
     attr_reader :before_callbacks, :prepend_before_callbacks
@@ -44,6 +43,7 @@ module Dk
       @ssh_args                 = DEFAULT_SSH_ARGS.dup
       @host_ssh_args            = DEFAULT_HOST_SSH_ARGS.dup
       @tasks                    = DEFAULT_TASKS.dup
+      @stdout_log_level         = DEFAULT_STDOUT_LOG_LEVEL
       @log_pattern              = DEFAULT_LOG_PATTERN
       @log_file                 = nil
       @log_file_pattern         = DEFAULT_LOG_FILE_PATTERN
@@ -111,6 +111,11 @@ module Dk
       @tasks[name.to_s]
     end
 
+    def stdout_log_level(value = nil)
+      @stdout_log_level = value if !value.nil?
+      @stdout_log_level
+    end
+
     def log_pattern(value = nil)
       @log_pattern = value if !value.nil?
       @log_pattern
@@ -153,7 +158,7 @@ module Dk
         @config = config # set the reader first so it can be used when supering
 
         Logsly.stdout(@config.dk_logger_stdout_output_name) do |logger|
-          level   Dk::Config::STDOUT_LOG_LEVEL
+          level   logger.config.stdout_log_level
           pattern logger.config.log_pattern
         end
         outputs = [@config.dk_logger_stdout_output_name]

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -143,6 +143,18 @@ class Dk::CLI
 
   end
 
+  class RunWithVerboseFlagTests < InitTests
+    desc "and run with the --verbose flag"
+    setup do
+      @cli.run('--verbose')
+    end
+
+    should "set the stdout log level to 'debug'" do
+      assert_equal 'debug', Dk.config.stdout_log_level
+    end
+
+  end
+
   class RunWithHelpFlagTests < InitTests
     desc "and run with the --help flag"
     setup do

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -33,10 +33,10 @@ class Dk::Config
       assert_equal Hash.new,           subject::DEFAULT_TASKS
       assert_equal "%m\n",             subject::DEFAULT_LOG_PATTERN
       assert_equal '[%d %-5l] : %m\n', subject::DEFAULT_LOG_FILE_PATTERN
+      assert_equal 'info',             subject::DEFAULT_STDOUT_LOG_LEVEL
     end
 
-    should "know the log levels to use for each output" do
-      assert_equal 'info',  subject::STDOUT_LOG_LEVEL
+    should "know the file output log level" do
       assert_equal 'debug', subject::FILE_LOG_LEVEL
     end
 
@@ -59,7 +59,7 @@ class Dk::Config
     should have_imeths :prepend_before_callback_task_classes
     should have_imeths :after_callback_task_classes
     should have_imeths :prepend_after_callback_task_classes
-    should have_imeths :task
+    should have_imeths :task, :stdout_log_level
     should have_imeths :log_pattern, :log_file, :log_file_pattern
     should have_imeths :dk_logger_stdout_output_name, :dk_logger_file_output_name
     should have_imeths :dk_logger
@@ -75,6 +75,7 @@ class Dk::Config
       assert_equal @config_class::DEFAULT_SSH_ARGS,         subject.ssh_args
       assert_equal @config_class::DEFAULT_HOST_SSH_ARGS,    subject.host_ssh_args
       assert_equal @config_class::DEFAULT_TASKS,            subject.tasks
+      assert_equal @config_class::DEFAULT_STDOUT_LOG_LEVEL, subject.stdout_log_level
       assert_equal @config_class::DEFAULT_LOG_PATTERN,      subject.log_pattern
       assert_equal @config_class::DEFAULT_LOG_FILE_PATTERN, subject.log_file_pattern
 
@@ -164,6 +165,14 @@ class Dk::Config
       end
     end
 
+    should "know its stdout log level" do
+      level = Factory.string
+
+      assert_equal @config_class::DEFAULT_STDOUT_LOG_LEVEL, subject.stdout_log_level
+      assert_equal level, subject.stdout_log_level(level)
+      assert_equal level, subject.stdout_log_level
+    end
+
     should "know its log pattern" do
       pattern = Factory.string
 
@@ -239,8 +248,8 @@ class Dk::Config
       assert_instance_of Logsly::Outputs::Stdout, out
 
       data = out.data(subject)
-      assert_equal @config_class::STDOUT_LOG_LEVEL, data.level
-      assert_equal @config.log_pattern,             data.pattern
+      assert_equal @config.stdout_log_level, data.level
+      assert_equal @config.log_pattern,      data.pattern
     end
 
   end


### PR DESCRIPTION
This flag set the stdout log level to 'debug' instead fo the
default 'info' level.  To do this feature, I had to build into
the Config the ability to set a stdout log level and then honor
it in the config's logger.  I also added the option to the CLI
and had it set the 'debug' log level if the option is present.

@jcredding ready for review.
