### PR TITLE
add `:dry_tree_run` cmd/ssh opt to run cmds w/ the dry/tree runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,24 @@ Use the `ssh` helper to run remote system cmds on hosts using ssh.  Like the nor
 
 The `ssh!` helper is identical to the `ssh` helper except that it raises a `Dk::Task::SSHRunError` if the command was not successful.
 
+##### `:dry_tree_run` cmd/ssh opt
+
+```ruby
+require 'dk/task'
+
+class MyTask
+  include Dk::Task
+
+  def run!
+    cmd! "test -d some_file", :dry_tree_run => true
+    ssh! "test -d some_file", :dry_tree_run => true
+  end
+
+end
+```
+
+Use this option to force the cmd/ssh to *always* run, even using the `--dry-run` and `--tree` CLI options (which put Scmd in test mode and don't run any cmds by default).  The idea is that some cmds are essential to the running of the task and if they don't actually run, the task will error out.  This is handy for tasks that don't change anything they just read data and that data is used to determine how a task should proceed.  This allows you to still get the advantages of the dry run and tree CLI options.
+
 ##### `halt`
 
 ```ruby

--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -50,7 +50,8 @@ module Dk::Local
   class Cmd < BaseCmd
 
     def initialize(cmd_str, opts = nil)
-      super(Scmd, cmd_str, opts)
+      opts ||= {}
+      super(opts[:dry_tree_run] ? Scmd::Command : Scmd, cmd_str, opts)
     end
 
   end

--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -28,7 +28,9 @@ module Dk::Remote
       @local_cmds = @hosts.inject({}) do |cmds, host|
         cmds[host] = local_cmd_or_spy_klass.new(
           ssh_cmd_str(@cmd_str, host, @ssh_args, @host_ssh_args),
-          { :env => opts[:env] }
+          { :env          => opts[:env],
+            :dry_tree_run => opts[:dry_tree_run]
+          }
         )
         cmds
       end

--- a/test/unit/local_tests.rb
+++ b/test/unit/local_tests.rb
@@ -21,6 +21,12 @@ module Dk::Local
         @scmd_spy
       end
 
+      @scmd_cmd_new_called_with = nil
+      Assert.stub(Scmd::Command, :new) do |*args|
+        @scmd_cmd_new_called_with = args
+        @scmd_spy
+      end
+
       @scmd_spy_new_called_with = nil
       Assert.stub(Scmd::CommandSpy, :new) do |*args|
         @scmd_spy_new_called_with = args
@@ -102,12 +108,20 @@ module Dk::Local
       @cmd = @cmd_class.new(@cmd_str)
     end
 
-    should "build an scmd with the cmd str and any given options" do
+    should "build an Scmd with the cmd str and any given options" do
       assert_equal [@cmd_str, { :env => nil }], @scmd_new_called_with
 
       opts = { :env => Factory.string }
       cmd  = @cmd_class.new(@cmd_str, opts)
       assert_equal [@cmd_str, { :env => opts[:env] }], @scmd_new_called_with
+    end
+
+    should "build an Scmd::Command (to bypass test mode spying) if the dry/tree run option given" do
+      opts = { :dry_tree_run => true }
+      cmd  = @cmd_class.new(@cmd_str, opts)
+
+      exp = [@cmd_str, { :env => nil }]
+      assert_equal exp, @scmd_cmd_new_called_with
     end
 
   end

--- a/test/unit/remote_tests.rb
+++ b/test/unit/remote_tests.rb
@@ -14,7 +14,8 @@ module Dk::Remote
       @cmd_str       = Factory.string
 
       @opts = {
-        :env           => Factory.string,
+        :env           => { Factory.string => Factory.string },
+        :dry_tree_run  => Factory.boolean,
         :hosts         => @hosts,
         :ssh_args      => @ssh_args,
         :host_ssh_args => @host_ssh_args,
@@ -116,7 +117,10 @@ module Dk::Remote
         subject.ssh_args,
         subject.host_ssh_args
       )
-      exp_opts = { :env => @opts[:env] }
+      exp_opts = {
+        :env          => @opts[:env],
+        :dry_tree_run => @opts[:dry_tree_run]
+      }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_spy_new_called_with
 
       cmd = @cmd_class.new(Dk::Local::Cmd, @cmd_str, @opts)
@@ -131,7 +135,10 @@ module Dk::Remote
         cmd.ssh_args,
         cmd.host_ssh_args
       )
-      exp_opts = { :env => @opts[:env] }
+      exp_opts = {
+        :env          => @opts[:env],
+        :dry_tree_run => @opts[:dry_tree_run]
+      }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_new_called_with
     end
 
@@ -203,7 +210,10 @@ module Dk::Remote
         subject.ssh_args,
         subject.host_ssh_args
       )
-      exp_opts = { :env => nil }
+      exp_opts = {
+        :env          => nil,
+        :dry_tree_run => nil
+      }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_new_called_with
 
       cmd  = @cmd_class.new(@cmd_str, @opts)
@@ -218,7 +228,10 @@ module Dk::Remote
         cmd.ssh_args,
         cmd.host_ssh_args
       )
-      exp_opts = { :env => @opts[:env] }
+      exp_opts = {
+        :env          => @opts[:env],
+        :dry_tree_run => @opts[:dry_tree_run]
+      }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_new_called_with
     end
 
@@ -248,7 +261,10 @@ module Dk::Remote
         subject.ssh_args,
         subject.host_ssh_args
       )
-      exp_opts = { :env => nil }
+      exp_opts = {
+        :env          => nil,
+        :dry_tree_run => nil
+      }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_spy_new_called_with
 
       cmd = @cmd_class.new(@cmd_str, @opts)
@@ -263,7 +279,10 @@ module Dk::Remote
         cmd.ssh_args,
         cmd.host_ssh_args
       )
-      exp_opts = { :env => @opts[:env] }
+      exp_opts = {
+        :env          => @opts[:env],
+        :dry_tree_run => @opts[:dry_tree_run]
+      }
       assert_equal [exp_cmd_str, exp_opts], @local_cmd_spy_new_called_with
     end
 


### PR DESCRIPTION
Some tasks may rely on the output of a cmd or some state set by
an ssh to proceed and if those cmds aren't run the task will fail.
The dry/tree runners by default never run cmds (they just spy
them).  For these cmds that are essential to the task, use this
new option to force that they always run so you can still take
advantage of the `--dry-run` and `--tree` CLI options.

@jcredding ready for review.
