### PR TITLE
have the TreeRunner output the tasks that were run

### DIFF
--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -89,8 +89,14 @@ module Dk
       if opts['dry-run'] || opts['tree']
         ENV['SCMD_TEST_MODE'] = '1' # disable all local/remote cmds
       end
+
       return Dk::DryRunner.new(config) if opts['dry-run']
-      return Dk::TreeRunner.new(config, @kernel) if opts['tree']
+
+      if opts['tree']
+        @kernel.puts "building task tree#{'s' if @clirb.args.size > 1}..."
+        return Dk::TreeRunner.new(config, @kernel)
+      end
+
       Dk::DkRunner.new(config)
     end
 

--- a/lib/dk/tree_runner.rb
+++ b/lib/dk/tree_runner.rb
@@ -8,16 +8,30 @@ module Dk
   class TreeRunner < DryRunner
     include HasTheRuns
 
+    LEVEL_PREFIX = '    '.freeze
+    LEVEL_BULLET = '|-- '.freeze
+
     def initialize(config, kernel)
       super(config, :logger => NullLogger.new) # disable any logging
 
       @task_run_stack = [self]
+      @run_num        = 0
       @kernel         = kernel
     end
 
     def run(*args)
+      # wipe the task runs before every run; that way `output_task_runs` outputs
+      # just this run's task runs
+      self.runs.clear
+
+      # increment the run num and run the task
+      @run_num += 1
       task = super
-      @kernel.puts "TODO: task tree output goes here"
+
+      # recursively output the task runs in a tree format
+      output_task_runs(self.runs, 0, "#{@run_num}) ".rjust(LEVEL_PREFIX.size, ' '))
+
+      # return the top-level task that was run
       task
     end
 
@@ -32,6 +46,17 @@ module Dk
       task = super(task_class, params)
       @task_run_stack.pop
       task
+    end
+
+    def output_task_runs(runs, level, prefix = nil)
+      runs.each do |task_run|
+        # recursively output the prefix and task class on indented, bulleted lines
+        @kernel.puts "#{LEVEL_PREFIX*level}" \
+                     "#{LEVEL_BULLET if level > 0}" \
+                     "#{prefix}#{task_run.task_class}"
+        output_task_runs(task_run.runs, level+1)
+      end
+
     end
 
   end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -99,7 +99,7 @@ class Dk::CLI
 
   end
 
-  class RunWithDryTreeFlagTests < InitTests
+  class RunWithTreeFlagTests < InitTests
     desc "and run with the --tree flag"
     setup do
       @runner_init_with = nil
@@ -120,6 +120,12 @@ class Dk::CLI
       assert_equal [CLITestTask],            @runner_run_with
 
       assert_equal 0, @kernel_spy.exit_status
+      assert_match /^building task tree\.\.\./, @kernel_spy.output
+
+      kernel_spy = KernelSpy.new
+      cli = Dk::CLI.new(kernel_spy)
+      cli.run('cli-test-task', 'cli-test-task', '--tree')
+      assert_match /^building task trees\.\.\./, kernel_spy.output
     end
 
   end

--- a/test/unit/tree_runner_tests.rb
+++ b/test/unit/tree_runner_tests.rb
@@ -26,6 +26,11 @@ class Dk::TreeRunner
       assert_includes Dk::HasTheRuns, subject
     end
 
+    should "know its output level prefix/bullet" do
+      assert_equal '    ', subject::LEVEL_PREFIX
+      assert_equal '|-- ', subject::LEVEL_BULLET
+    end
+
   end
 
   class InitTests < UnitTests
@@ -87,7 +92,16 @@ class Dk::TreeRunner
     end
 
     should "output some info describing the tree of tasks that were run" do
-      exp = "TODO: task tree output goes here\n"
+      exp = " 1) Dk::TreeRunner::TestTask\n" \
+            "    |-- Dk::TreeRunner::TestTask::SubTask\n" \
+            "        |-- Dk::TreeRunner::TestTask::SubSubTask\n"
+      assert_equal exp, @kernal_puts_output
+
+      @runner.run(TestTask, @params)
+
+      exp += " 2) Dk::TreeRunner::TestTask\n" \
+             "    |-- Dk::TreeRunner::TestTask::SubTask\n" \
+             "        |-- Dk::TreeRunner::TestTask::SubSubTask\n"
       assert_equal exp, @kernal_puts_output
     end
 


### PR DESCRIPTION
This updates the TreeRunner so that it outputs the tasks that
were run in a tree display.  It counts the run number associated
with each top-level task that is run and for each outputs a tree
display of the task and any sub-tasks (recusively) that were run
b/c of the top-level task.

```
$ dk --tree test-task test-task
building task trees...
 1) Dk::TreeRunner::TestTask
    |-- Dk::TreeRunner::TestTask::SubTask
        |-- Dk::TreeRunner::TestTask::SubSubTask
 2) Dk::TreeRunner::TestTask
    |-- Dk::TreeRunner::TestTask::SubTask
        |-- Dk::TreeRunner::TestTask::SubSubTask

```

Note: the run numbers in the output have been justified to
support running up to 99 top-level tasks at once without any
formatting issues.

The goal here is to help debug/validate your tasks and make sure
what will be run is what you expect to be run.

@jcredding ready for review.
