### PR TITLE
make the `run_only_once` task behavior more robust

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -53,12 +53,12 @@ module Dk
 
     # called by CLI on top-level tasks
     def run(task_class, params = nil)
-      build_and_run_task(task_class, params)
+      check_run_once_and_build_and_run_task(task_class, params)
     end
 
     # called by other tasks on sub-tasks
     def run_task(task_class, params = nil)
-      build_and_run_task(task_class, params)
+      check_run_once_and_build_and_run_task(task_class, params)
     end
 
     def log_info(msg);  self.logger.info(msg);  end # TODO: style up
@@ -78,6 +78,14 @@ module Dk
     end
 
     private
+
+    def check_run_once_and_build_and_run_task(task_class, params = nil)
+      if task_class.run_only_once && self.has_run_task?(task_class)
+        build_task(task_class, params)
+      else
+        build_and_run_task(task_class, params)
+      end
+    end
 
     def build_and_run_task(task_class, params = nil)
       build_task(task_class, params).tap do |task|

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -23,10 +23,7 @@ module Dk
 
       def dk_run
         self.dk_run_callbacks 'before'
-        catch(:halt) do
-          halt if self.class.run_only_once && @dk_runner.has_run_task?(self.class)
-          self.run!
-        end
+        catch(:halt){ self.run! }
         self.dk_run_callbacks 'after'
       end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -114,7 +114,7 @@ class Dk::Runner
       assert_equal [callback], runner.task_callback_task_classes(name, subject)
     end
 
-    should "build and run a given task class" do
+    should "build and run a given task class, honoring any run only once setting" do
       params = { Factory.string => Factory.string }
 
       task = subject.run(TestTask)
@@ -132,6 +132,24 @@ class Dk::Runner
       task = subject.run_task(TestTask, params)
       assert_true task.run_called
       assert_equal params, task.run_params
+
+      TestTask.run_only_once(true)
+
+      task = subject.run(TestTask)
+      assert_nil task.run_called
+      assert_nil task.run_params
+
+      task = subject.run(TestTask, params)
+      assert_nil task.run_called
+      assert_nil task.run_params
+
+      task = subject.run_task(TestTask)
+      assert_nil task.run_called
+      assert_nil task.run_params
+
+      task = subject.run_task(TestTask, params)
+      assert_nil task.run_called
+      assert_nil task.run_params
     end
 
     should "call to its logger for its log_* methods" do

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -237,6 +237,8 @@ module Dk::Task
       CallbacksTask.run_only_once false
     end
 
+    # the logic controlling this is in the runner, however this test exists
+    # as sort of a 'system-y' test to ensure the logic at the task level
     should "run only once" do
       @call_orders.reset
       @runner.run(CallbacksTask)


### PR DESCRIPTION
Before the run once logic was only tested at the Task's `run!`
method.  While this prevented any logic from running multiple
times, it had the overhead of the task's callbacks continuing to
be run even though the task itself and any tasks run in the `run!`
method would not be run.  This was inconsistent and not in the
spirit of the feature.

I noticed this when debugging the `--tree` CLI option.  I noticed
I had repeated tree entries for run-only-once tasks.

This moves the checking logic to the runner level.  Now if a
task is run-only-once, it is just built and returned and never
run at all.  Otherwise it is built and run normally.  This
prevents the TreeRunner from ever building and logging a task
run for the task and fixes the `--tree` CLI option issue.

@jcredding ready for review.
