### PR TITLE
track task callbacks using a CallbackSet

### DIFF
--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -17,7 +17,7 @@ module Dk
 
     DEFAULT_INIT_PROCS       = [].freeze
     DEFAULT_PARAMS           = {}.freeze
-    DEFAULT_CALLBACKS        = Hash.new{ |h, k| h[k] = [] }.freeze
+    DEFAULT_CALLBACKS        = Hash.new{ |h, k| h[k] = Dk::Task::CallbackSet.new }.freeze
     DEFAULT_SSH_HOSTS        = {}.freeze
     DEFAULT_SSH_ARGS         = ''.freeze
     DEFAULT_HOST_SSH_ARGS    = Hash.new{ |h, k| h[k] = DEFAULT_SSH_ARGS }

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -140,6 +140,45 @@ class Dk::Config
       assert_equal exp, subject.prepend_after_callback_task_classes(subj_task_class)
     end
 
+    should "not duplicate callback tasks if they've already been added" do
+      subj_task_class  = Class.new{ include Dk::Task }
+      other_task_class = Factory.string
+      cb_task_class    = Factory.string
+      cb_params        = Factory.string
+
+      subject.before(subj_task_class, other_task_class)
+      subject.before(subj_task_class, other_task_class)
+      assert_equal 1, subject.before_callbacks[subj_task_class].size
+
+      subject.before(subj_task_class, cb_task_class, cb_params)
+      subject.before(subj_task_class, cb_task_class, cb_params)
+      assert_equal 2, subject.before_callbacks[subj_task_class].size
+
+      subject.after(subj_task_class, other_task_class)
+      subject.after(subj_task_class, other_task_class)
+      assert_equal 1, subject.after_callbacks[subj_task_class].size
+
+      subject.after(subj_task_class, cb_task_class, cb_params)
+      subject.after(subj_task_class, cb_task_class, cb_params)
+      assert_equal 2, subject.after_callbacks[subj_task_class].size
+
+      subject.prepend_before(subj_task_class, other_task_class)
+      subject.prepend_before(subj_task_class, other_task_class)
+      assert_equal 1, subject.prepend_before_callbacks[subj_task_class].size
+
+      subject.prepend_before(subj_task_class, cb_task_class, cb_params)
+      subject.prepend_before(subj_task_class, cb_task_class, cb_params)
+      assert_equal 2, subject.prepend_before_callbacks[subj_task_class].size
+
+      subject.prepend_after(subj_task_class, other_task_class)
+      subject.prepend_after(subj_task_class, other_task_class)
+      assert_equal 1, subject.prepend_after_callbacks[subj_task_class].size
+
+      subject.prepend_after(subj_task_class, cb_task_class, cb_params)
+      subject.prepend_after(subj_task_class, cb_task_class, cb_params)
+      assert_equal 2, subject.prepend_after_callbacks[subj_task_class].size
+    end
+
     should "add callable tasks" do
       assert_empty subject.tasks
 


### PR DESCRIPTION
This is an array that behaves like a Set.  It prevents duplicate
callbacks from being added to any one callback group.  Also, when
the Config callbacks are combined with the Task callbacks, a set
is used to prevent any duplicates across groups.  The only
duplicates that will run are if one callback is added as both a
"before" callback and an "after" callback.

The goal of all this is to be forgiving in the case that mixins
or 3rd-party extensions unknowingly add the same callback twice.
It also helps in the case a task at run-time adds a callback. We
don't want to duplicate callbacks each time a task is run.

I chose to implement a custom set object both b/c I added a custom
method to combine sets but also b/c Sets don't respond to the
push ('shovel', `<<`) and unshift methods.

@jcredding ready for review.  Are you cool with how I test this?  I basically just added the same callbacks twice and made sure things passed.  I have 1 semi-specific test for the config callbacks.  They're kinda system-y but couldn't think of a better way.  I also didn't test the `CallbackSet` obj b/c I figure it is an implementation detail.  Cool by you?
