### PR TITLE
Add `Dk::HasTheStubs` mixin, use in test and dry runner

### DIFF
--- a/dk.gemspec
+++ b/dk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert", ["~> 2.16.2"])
 
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
-  gem.add_dependency("scmd",        ["~> 3.0.2"])
+  gem.add_dependency("scmd",        ["~> 3.0.3"])
   gem.add_dependency("logsly",      ["~> 1.3.2"])
 
 end

--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -86,10 +86,6 @@ module Dk
     end
 
     def get_runner(config, opts)
-      if opts['dry-run'] || opts['tree']
-        ENV['SCMD_TEST_MODE'] = '1' # disable all local/remote cmds
-      end
-
       return Dk::DryRunner.new(config) if opts['dry-run']
 
       if opts['tree']

--- a/lib/dk/dry_runner.rb
+++ b/lib/dk/dry_runner.rb
@@ -1,10 +1,26 @@
 require 'dk/config_runner'
+require 'dk/has_the_stubs'
 
 module Dk
 
   class DryRunner < ConfigRunner
+    include HasTheStubs
 
     # run with disabled cmds, just log actions, but run all sub-tasks
+
+    private
+
+    def has_the_stubs_build_local_cmd(cmd_str, given_opts)
+      given_opts ||= {}
+      cmd_klass = given_opts[:dry_tree_run] ? Local::Cmd : Local::CmdSpy
+      cmd_klass.new(cmd_str, given_opts)
+    end
+
+    def has_the_stubs_build_remote_cmd(cmd_str, ssh_opts)
+      ssh_opts ||= {}
+      cmd_klass = ssh_opts[:dry_tree_run] ? Remote::Cmd : Remote::CmdSpy
+      cmd_klass.new(cmd_str, ssh_opts)
+    end
 
   end
 

--- a/lib/dk/has_the_stubs.rb
+++ b/lib/dk/has_the_stubs.rb
@@ -1,0 +1,121 @@
+require 'much-plugin'
+require 'dk/local'
+require 'dk/remote'
+
+module Dk
+
+  module HasTheStubs
+    include MuchPlugin
+
+    plugin_included do
+      include InstanceMethods
+
+    end
+
+    module InstanceMethods
+
+      # cmd stub api
+
+      def stub_cmd(cmd_str, *args, &block)
+        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+        input      = args.last
+        local_cmd_spy_blocks[cmd_spy_key(cmd_str, input, given_opts)] = block
+      end
+
+      def unstub_cmd(cmd_str, *args)
+        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+        input      = args.last
+
+        key = cmd_spy_key(cmd_str, input, given_opts)
+        local_cmd_spy_blocks.delete(key)
+        local_cmd_spies.delete(key)
+      end
+
+      def unstub_all_cmds
+        local_cmd_spy_blocks.clear
+        local_cmd_spies.clear
+      end
+
+      # ssh stub API
+
+      def stub_ssh(cmd_str, *args, &block)
+        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+        input      = args.last
+        remote_cmd_spy_blocks[cmd_spy_key(cmd_str, input, given_opts)] = block
+      end
+
+      def unstub_ssh(cmd_str, *args)
+        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+        input      = args.last
+
+        key = cmd_spy_key(cmd_str, input, given_opts)
+        remote_cmd_spy_blocks.delete(key)
+        remote_cmd_spies.delete(key)
+      end
+
+      def unstub_all_ssh
+        remote_cmd_spy_blocks.clear
+        remote_cmd_spies.clear
+      end
+
+      private
+
+      # if the cmd is stubbed, build a spy and apply the stub (or return the
+      # cached spy), otherwise let the runner decide how to handle the local
+      # cmd
+      def build_local_cmd(cmd_str, input, given_opts)
+        key = cmd_spy_key(cmd_str, input, given_opts)
+        if (block = local_cmd_spy_blocks[key])
+          local_cmd_spies[key] ||= Local::CmdSpy.new(cmd_str, given_opts).tap(&block)
+        else
+          has_the_stubs_build_local_cmd(cmd_str, given_opts)
+        end
+      end
+
+      def has_the_stubs_build_local_cmd(cmd_str, given_opts)
+        raise NotImplementedError
+      end
+
+      def local_cmd_spies
+        @local_cmd_spies ||= {}
+      end
+
+      def local_cmd_spy_blocks
+        @local_cmd_spy_blocks ||= {}
+      end
+
+      # if the cmd is stubbed, build a spy and apply the stub (or return the
+      # cached spy), otherwise let the runner decide how to handle the remote
+      # cmd; when building the spy use the ssh opts, this allows stubbing and
+      # calling ssh cmds with the same opts but also allows building a valid
+      # remote cmd that has an ssh host
+      def build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
+        key = cmd_spy_key(cmd_str, input, given_opts)
+        if (block = remote_cmd_spy_blocks[key])
+          remote_cmd_spies[key] ||= Remote::CmdSpy.new(cmd_str, ssh_opts).tap(&block)
+        else
+          has_the_stubs_build_remote_cmd(cmd_str, ssh_opts)
+        end
+      end
+
+      def has_the_stubs_build_remote_cmd(cmd_str, ssh_opts)
+        raise NotImplementedError
+      end
+
+      def remote_cmd_spies
+        @remote_cmd_spies ||= {}
+      end
+
+      def remote_cmd_spy_blocks
+        @remote_cmd_spy_blocks ||= {}
+      end
+
+      def cmd_spy_key(cmd_str, input, given_opts)
+        [cmd_str, input, given_opts]
+      end
+
+    end
+
+  end
+
+end

--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -50,8 +50,7 @@ module Dk::Local
   class Cmd < BaseCmd
 
     def initialize(cmd_str, opts = nil)
-      opts ||= {}
-      super(opts[:dry_tree_run] ? Scmd::Command : Scmd, cmd_str, opts)
+      super(Scmd, cmd_str, opts)
     end
 
   end

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -1,4 +1,5 @@
 require 'dk/has_the_runs'
+require 'dk/has_the_stubs'
 require 'dk/local'
 require 'dk/remote'
 require 'dk/runner'
@@ -8,18 +9,13 @@ module Dk
 
   class TestRunner < Runner
     include HasTheRuns
-
-    SCMD_TEST_MODE_VALUE = 'yes'.freeze
+    include HasTheStubs
 
     attr_accessor :task_class
 
     # test runners are designed to only run their task
     def run(params = nil)
-      orig_scmd_test_mode = ENV['SCMD_TEST_MODE']
-      ENV['SCMD_TEST_MODE'] = SCMD_TEST_MODE_VALUE
-      task = self.task(params).tap(&:dk_run)
-      ENV['SCMD_TEST_MODE'] = orig_scmd_test_mode
-      task
+      self.task(params).tap(&:dk_run)
     end
 
     # don't run any sub-tasks, just track that a sub-task was run
@@ -43,91 +39,14 @@ module Dk
       @task ||= build_task(self.task_class, params)
     end
 
-    # cmd stub API
-
-    def stub_cmd(cmd_str, *args, &block)
-      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-      input      = args.last
-      local_cmd_spy_blocks[cmd_spy_key(cmd_str, input, given_opts)] = block
-    end
-
-    def unstub_cmd(cmd_str, *args)
-      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-      input      = args.last
-
-      key = cmd_spy_key(cmd_str, input, given_opts)
-      local_cmd_spy_blocks.delete(key)
-      local_cmd_spies.delete(key)
-    end
-
-    def unstub_all_cmds
-      local_cmd_spy_blocks.clear
-      local_cmd_spies.clear
-    end
-
-    # ssh stub API
-
-    def stub_ssh(cmd_str, *args, &block)
-      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-      input      = args.last
-      remote_cmd_spy_blocks[cmd_spy_key(cmd_str, input, given_opts)] = block
-    end
-
-    def unstub_ssh(cmd_str, *args)
-      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-      input      = args.last
-
-      key = cmd_spy_key(cmd_str, input, given_opts)
-      remote_cmd_spy_blocks.delete(key)
-      remote_cmd_spies.delete(key)
-    end
-
-    def unstub_all_ssh
-      remote_cmd_spy_blocks.clear
-      remote_cmd_spies.clear
-    end
-
     private
 
-    # don't run any local cmds, always return spies that act like local cmds
-    def build_local_cmd(cmd_str, input, given_opts)
-      key = cmd_spy_key(cmd_str, input, given_opts)
-      local_cmd_spies[key] ||= begin
-        block = local_cmd_spy_blocks[key] || Proc.new{ |spy| }
-        Local::CmdSpy.new(cmd_str, given_opts).tap(&block)
-      end
+    def has_the_stubs_build_local_cmd(cmd_str, given_opts)
+      Local::CmdSpy.new(cmd_str, given_opts)
     end
 
-    def local_cmd_spies
-      @local_cmd_spies ||= {}
-    end
-
-    def local_cmd_spy_blocks
-      @local_cmd_spy_blocks ||= {}
-    end
-
-    # don't run any remote cmds, always return spies that act like remote cmds;
-    # lookup cmd spies using the given opts but build them using the ssh opts,
-    # this allows stubbing and calling ssh cmds with the same opts but also
-    # allows building a valid remote cmd that has an ssh host
-    def build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
-      key = cmd_spy_key(cmd_str, input, given_opts)
-      remote_cmd_spies[key] ||= begin
-        block = remote_cmd_spy_blocks[key] || Proc.new{ |spy| }
-        Remote::CmdSpy.new(cmd_str, ssh_opts).tap(&block)
-      end
-    end
-
-    def remote_cmd_spies
-      @remote_cmd_spies ||= {}
-    end
-
-    def remote_cmd_spy_blocks
-      @remote_cmd_spy_blocks ||= {}
-    end
-
-    def cmd_spy_key(cmd_str, input, given_opts)
-      [cmd_str, input, given_opts]
+    def has_the_stubs_build_remote_cmd(cmd_str, ssh_opts)
+      Remote::CmdSpy.new(cmd_str, ssh_opts)
     end
 
   end

--- a/test/system/has_the_stubs_tests.rb
+++ b/test/system/has_the_stubs_tests.rb
@@ -1,0 +1,412 @@
+require 'assert'
+require 'dk/has_the_stubs'
+
+require 'stringio'
+require 'dk/config'
+require 'dk/dry_runner'
+require 'dk/tree_runner'
+require 'dk/test_runner'
+
+module Dk::HasTheStubs
+
+  class SystemTests < Assert::Context
+    desc "Dk::HasTheStubs"
+
+  end
+
+  class RunnerTests < SystemTests
+    desc "used by a runner"
+    setup do
+      @runner_class = [
+        Dk::DryRunner,
+        Dk::TreeRunner,
+        Dk::TestRunner
+      ].sample
+
+      # turn off the stdout logging
+      @dk_config = Dk::Config.new
+      @logger    = Dk::NullLogger.new
+      Assert.stub(@dk_config, :dk_logger){ @logger }
+
+      @task_class = StubTestTask
+      @runner     = build_runner(@task_class)
+
+      @cmd_str   = Factory.string
+      @cmd_input = Factory.string
+      @cmd_opts  = { Factory.string => Factory.string }
+
+      @params = {
+        'use_bang'  => false,
+        'cmd_str'   => @cmd_str,
+        'cmd_input' => @cmd_input,
+        'cmd_opts'  => @cmd_opts
+      }
+    end
+
+    private
+
+    def build_runner(task_class)
+      if @runner_class == Dk::TestRunner
+        @runner_class.new(:logger => @logger).tap{ |r| r.task_class = task_class }
+      elsif @runner_class == Dk::TreeRunner
+        @runner_class.new(@dk_config, StringIO.new)
+      else
+        @runner_class.new(@dk_config)
+      end
+    end
+
+    def run_runner(runner, task_class, params)
+      if @runner_class == Dk::TestRunner
+        runner.run(params)
+      else
+        runner.run(task_class, params)
+      end
+    end
+
+    def add_stubs(runner, local)
+      method = local ? :stub_cmd : :stub_ssh
+
+      @only_cmd_stdout  = Factory.stdout
+      @only_cmd_stderr  = Factory.stderr
+      @only_cmd_success = Factory.boolean
+      @only_cmd_spy     = nil
+      @runner.send(method, @cmd_str) do |spy|
+        spy.stdout     = @only_cmd_stdout
+        spy.stderr     = @only_cmd_stderr
+        spy.exitstatus = @only_cmd_success ? 0 : 1
+        @only_cmd_spy  = spy
+      end
+
+      @with_input_cmd_stdout  = Factory.stdout
+      @with_input_cmd_stderr  = Factory.stderr
+      @with_input_cmd_success = Factory.boolean
+      @with_input_cmd_spy     = nil
+      @runner.send(method, @cmd_str, @cmd_input) do |spy|
+        spy.stdout          = @with_input_cmd_stdout
+        spy.stderr          = @with_input_cmd_stderr
+        spy.exitstatus      = @with_input_cmd_success ? 0 : 1
+        @with_input_cmd_spy = spy
+      end
+
+      @with_opts_cmd_stdout  = Factory.stdout
+      @with_opts_cmd_stderr  = Factory.stderr
+      @with_opts_cmd_success = Factory.boolean
+      @with_opts_cmd_spy     = nil
+      @runner.send(method, @cmd_str, @cmd_opts) do |spy|
+        spy.stdout         = @with_opts_cmd_stdout
+        spy.stderr         = @with_opts_cmd_stderr
+        spy.exitstatus     = @with_opts_cmd_success ? 0 : 1
+        @with_opts_cmd_spy = spy
+      end
+
+      @with_all_cmd_stdout  = Factory.stdout
+      @with_all_cmd_stderr  = Factory.stderr
+      @with_all_cmd_success = Factory.boolean
+      @with_all_cmd_spy     = nil
+      @runner.send(method, @cmd_str, @cmd_input, @cmd_opts) do |spy|
+        spy.stdout        = @with_all_cmd_stdout
+        spy.stderr        = @with_all_cmd_stderr
+        spy.exitstatus    = @with_all_cmd_success ? 0 : 1
+        @with_all_cmd_spy = spy
+      end
+    end
+
+  end
+
+  class CmdStubTests < RunnerTests
+    setup do
+      @params.merge!('local' => true)
+      add_stubs(@runner, @params['local'])
+    end
+
+    should "allow stubbing `cmd` calls" do
+      task = run_runner(@runner, @task_class, @params)
+
+      # ensure calls return the cmd spy they are stubbed with
+      assert_same @only_cmd_spy,       task.only_cmd
+      assert_same @with_input_cmd_spy, task.with_input_cmd
+      assert_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_same @with_all_cmd_spy,   task.with_all_cmd
+
+      # ensure the cmd spies are local spies
+      assert_false @only_cmd_spy.ssh?
+      assert_false @with_input_cmd_spy.ssh?
+      assert_false @with_opts_cmd_spy.ssh?
+      assert_false @with_all_cmd_spy.ssh?
+
+      # ensure cmd spies are run
+      assert_true @only_cmd_spy.run_called?
+      assert_true @with_input_cmd_spy.run_called?
+      assert_true @with_opts_cmd_spy.run_called?
+      assert_true @with_all_cmd_spy.run_called?
+
+      # ensure stubs can set stdout
+      assert_equal @only_cmd_stdout,       @only_cmd_spy.stdout
+      assert_equal @with_input_cmd_stdout, @with_input_cmd_spy.stdout
+      assert_equal @with_opts_cmd_stdout,  @with_opts_cmd_spy.stdout
+      assert_equal @with_all_cmd_stdout,   @with_all_cmd_spy.stdout
+
+      # ensure stubs can set stderr
+      assert_equal @only_cmd_stderr,       @only_cmd_spy.stderr
+      assert_equal @with_input_cmd_stderr, @with_input_cmd_spy.stderr
+      assert_equal @with_opts_cmd_stderr,  @with_opts_cmd_spy.stderr
+      assert_equal @with_all_cmd_stderr,   @with_all_cmd_spy.stderr
+
+      # ensure stubs can set exitstatus
+      assert_equal @only_cmd_success,       @only_cmd_spy.success?
+      assert_equal @with_input_cmd_success, @with_input_cmd_spy.success?
+      assert_equal @with_opts_cmd_success,  @with_opts_cmd_spy.success?
+      assert_equal @with_all_cmd_success,   @with_all_cmd_spy.success?
+    end
+
+    should "allow stubbing `cmd!` calls" do
+      @params['use_bang'] = true
+      task = run_runner(@runner, @task_class, @params)
+
+      # ensure stubs can control whether a `cmd!` raises an error or not
+
+      if @only_cmd_success
+        assert_equal @only_cmd_spy, task.only_cmd
+      else
+        assert_true task.only_cmd_failed
+      end
+
+      if @with_input_cmd_success
+        assert_equal @with_input_cmd_spy, task.with_input_cmd
+      else
+        assert_true task.with_input_cmd_failed
+      end
+
+      if @with_opts_cmd_success
+        assert_equal @with_opts_cmd_spy, task.with_opts_cmd
+      else
+        assert_true task.with_opts_cmd_failed
+      end
+
+      if @with_all_cmd_success
+        assert_equal @with_all_cmd_spy, task.with_all_cmd
+      else
+        assert_true task.with_all_cmd_failed
+      end
+    end
+
+    should "unstub specific cmd spies" do
+      @runner.unstub_cmd(@cmd_str)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,   task.only_cmd
+      assert_same @with_input_cmd_spy, task.with_input_cmd
+      assert_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_same @with_all_cmd_spy,   task.with_all_cmd
+
+      @runner.unstub_cmd(@cmd_str, @cmd_input)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_same @with_opts_cmd_spy,      task.with_opts_cmd
+      assert_same @with_all_cmd_spy,       task.with_all_cmd
+
+      @runner.unstub_cmd(@cmd_str, @cmd_opts)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_not_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_same @with_all_cmd_spy,       task.with_all_cmd
+
+      @runner.unstub_cmd(@cmd_str, @cmd_input, @cmd_opts)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_not_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_not_same @with_all_cmd_spy,   task.with_all_cmd
+    end
+
+    should "unstub all cmd spies" do
+      @runner.unstub_all_cmds
+      @params['use_bang'] = Factory.boolean
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_not_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_not_same @with_all_cmd_spy,   task.with_all_cmd
+    end
+
+  end
+
+  class SshStubTests < RunnerTests
+    setup do
+      @cmd_opts = Factory.ssh_cmd_opts
+      @params.merge!({
+        'local'    => false,
+        'cmd_opts' => @cmd_opts
+      })
+      add_stubs(@runner, @params['local'])
+    end
+
+    should "allow stubbing `ssh` calls" do
+      task = run_runner(@runner, @task_class, @params)
+
+      # ensure calls return the cmd spy they are stubbed with
+      assert_same @only_cmd_spy,       task.only_cmd
+      assert_same @with_input_cmd_spy, task.with_input_cmd
+      assert_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_same @with_all_cmd_spy,   task.with_all_cmd
+
+      # ensure the cmd spies are remote spies
+      assert_true @only_cmd_spy.ssh?
+      assert_true @with_input_cmd_spy.ssh?
+      assert_true @with_opts_cmd_spy.ssh?
+      assert_true @with_all_cmd_spy.ssh?
+
+      # ensure cmd spies are run
+      assert_true @only_cmd_spy.run_called?
+      assert_true @with_input_cmd_spy.run_called?
+      assert_true @with_opts_cmd_spy.run_called?
+      assert_true @with_all_cmd_spy.run_called?
+
+      # ensure stubs can set exitstatus
+      assert_equal @only_cmd_success,       @only_cmd_spy.success?
+      assert_equal @with_input_cmd_success, @with_input_cmd_spy.success?
+      assert_equal @with_opts_cmd_success,  @with_opts_cmd_spy.success?
+      assert_equal @with_all_cmd_success,   @with_all_cmd_spy.success?
+
+      # don't test stdout/stderr, they can't be read even though we set them,
+      # this tests that they can be set implicitly via in a stub via the
+      # `add_stubs` private method
+    end
+
+    should "allow stubbing `ssh!` calls" do
+      @params['use_bang'] = true
+      task = run_runner(@runner, @task_class, @params)
+
+      # ensure stubs can control whether a `ssh!` raises an error or not
+
+      if @only_cmd_success
+        assert_equal @only_cmd_spy, task.only_cmd
+      else
+        assert_true task.only_cmd_failed
+      end
+
+      if @with_input_cmd_success
+        assert_equal @with_input_cmd_spy, task.with_input_cmd
+      else
+        assert_true task.with_input_cmd_failed
+      end
+
+      if @with_opts_cmd_success
+        assert_equal @with_opts_cmd_spy, task.with_opts_cmd
+      else
+        assert_true task.with_opts_cmd_failed
+      end
+
+      if @with_all_cmd_success
+        assert_equal @with_all_cmd_spy, task.with_all_cmd
+      else
+        assert_true task.with_all_cmd_failed
+      end
+    end
+
+    should "unstub specific cmd spies" do
+      @runner.unstub_ssh(@cmd_str)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,   task.only_cmd
+      assert_same @with_input_cmd_spy, task.with_input_cmd
+      assert_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_same @with_all_cmd_spy,   task.with_all_cmd
+
+      @runner.unstub_ssh(@cmd_str, @cmd_input)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_same @with_opts_cmd_spy,      task.with_opts_cmd
+      assert_same @with_all_cmd_spy,       task.with_all_cmd
+
+      @runner.unstub_ssh(@cmd_str, @cmd_opts)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_not_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_same @with_all_cmd_spy,       task.with_all_cmd
+
+      @runner.unstub_ssh(@cmd_str, @cmd_input, @cmd_opts)
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_not_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_not_same @with_all_cmd_spy,   task.with_all_cmd
+    end
+
+    should "unstub all cmd spies" do
+      @runner.unstub_all_ssh
+      @params['use_bang'] = Factory.boolean
+      task = run_runner(@runner, @task_class, @params)
+
+      assert_not_same @only_cmd_spy,       task.only_cmd
+      assert_not_same @with_input_cmd_spy, task.with_input_cmd
+      assert_not_same @with_opts_cmd_spy,  task.with_opts_cmd
+      assert_not_same @with_all_cmd_spy,   task.with_all_cmd
+    end
+
+  end
+
+  class StubTestTask
+    include Dk::Task
+
+    attr_reader :only_cmd, :with_input_cmd, :with_opts_cmd, :with_all_cmd
+    attr_reader :only_cmd_failed, :with_input_cmd_failed
+    attr_reader :with_opts_cmd_failed, :with_all_cmd_failed
+
+    ssh_hosts 'test'
+
+    def run!
+      method = if params['local']
+        params['use_bang'] ? :cmd! : :cmd
+      else
+        params['use_bang'] ? :ssh! : :ssh
+      end
+
+      begin
+        @only_cmd = send(method, params['cmd_str'])
+        @only_cmd_failed = false
+      rescue CmdRunError, SSHRunError
+        @only_cmd_failed = true
+      end
+
+      begin
+        @with_input_cmd = send(method, params['cmd_str'], params['cmd_input'])
+        @with_input_cmd_failed = false
+      rescue CmdRunError, SSHRunError
+        @with_input_cmd_failed = true
+      end
+
+      begin
+        @with_opts_cmd = send(method, params['cmd_str'], params['cmd_opts'])
+        @with_opts_cmd_failed = false
+      rescue CmdRunError, SSHRunError
+        @with_opts_cmd_failed = true
+      end
+
+      begin
+        @with_all_cmd = send(
+          method,
+          params['cmd_str'],
+          params['cmd_input'],
+          params['cmd_opts']
+        )
+        @with_all_cmd_failed = false
+      rescue CmdRunError, SSHRunError
+        @with_all_cmd_failed = true
+      end
+    end
+
+  end
+
+end

--- a/test/system/runner_tests.rb
+++ b/test/system/runner_tests.rb
@@ -1,0 +1,204 @@
+require 'assert'
+require 'dk/runner'
+
+require 'stringio'
+require 'dk/config'
+require 'dk/dk_runner'
+require 'dk/dry_runner'
+require 'dk/null_logger'
+require 'dk/task'
+require 'dk/test_runner'
+require 'dk/tree_runner'
+
+class Dk::Runner
+
+  class SystemTests < Assert::Context
+
+  end
+
+  class DryTreeRunSystemTests < SystemTests
+    setup do
+      @task_class = Class.new do
+        include Dk::Task
+        ssh_hosts Factory.string
+
+        attr_reader :regular_cmd, :dry_tree_run_cmd, :stubbed_cmd
+        attr_reader :regular_ssh, :dry_tree_run_ssh, :stubbed_ssh
+
+        def run!
+          @regular_cmd      = cmd!(params['cmd_str'])
+          @dry_tree_run_cmd = cmd!(params['cmd_str'], :dry_tree_run => true)
+          @stubbed_cmd      = cmd!(params['stubbed_cmd_str'], :dry_tree_run => true)
+          @regular_ssh      = ssh!(params['cmd_str'])
+          @dry_tree_run_ssh = ssh!(params['cmd_str'], :dry_tree_run => true)
+          @stubbed_ssh      = ssh!(params['stubbed_cmd_str'], :dry_tree_run => true)
+        end
+      end
+
+      # turn off the stdout logging
+      @dk_config = Dk::Config.new
+      @logger    = Dk::NullLogger.new
+      Assert.stub(@dk_config, :dk_logger){ @logger }
+
+      @params = {
+        'cmd_str'         => Factory.string,
+        'stubbed_cmd_str' => Factory.string
+      }
+    end
+  end
+
+  class DTRDkRunnerSystemTests < DryTreeRunSystemTests
+    desc "DkRunner"
+    setup do
+      @runner = Dk::DkRunner.new(@dk_config)
+      @task   = @runner.run(@task_class, @params)
+    end
+    subject{ @task }
+
+    should "run all cmds/ssh regardless of the `dry_tree_run` opt" do
+      # scmd is in test mode so we can test its spy and see if it was run
+      # called; if scmd was run then as far as dk is concerned it ran the cmd
+      assert_instance_of Dk::Local::Cmd, @task.regular_cmd
+      assert_true @task.regular_cmd.scmd.run_called?
+      assert_instance_of Dk::Local::Cmd, @task.dry_tree_run_cmd
+      assert_true @task.dry_tree_run_cmd.scmd.run_called?
+      assert_instance_of Dk::Local::Cmd, @task.stubbed_cmd
+      assert_true @task.stubbed_cmd.scmd.run_called?
+
+      # check that the first local cmd of the remote cmd was run
+      assert_instance_of Dk::Remote::Cmd, @task.regular_ssh
+      assert_true @task.regular_ssh.local_cmds.values.first.scmd.start_called?
+      assert_instance_of Dk::Remote::Cmd, @task.dry_tree_run_ssh
+      assert_true @task.dry_tree_run_ssh.local_cmds.values.first.scmd.start_called?
+      assert_instance_of Dk::Remote::Cmd, @task.stubbed_ssh
+      assert_true @task.stubbed_ssh.local_cmds.values.first.scmd.start_called?
+    end
+
+  end
+
+  class DTRDryRunnerSystemTests < DryTreeRunSystemTests
+    desc "DryRunner"
+    setup do
+      @runner = Dk::DryRunner.new(@dk_config)
+
+      # stub a cmd/ssh using `dry_tree_run` so we can test that the stub takes
+      # precedence over the `dry_tree_run` opt
+      @runner.stub_cmd(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+        s.stdout = Factory.string
+      end
+      @runner.stub_ssh(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+        s.stdout = Factory.string
+      end
+
+      @task = @runner.run(@task_class, @params)
+    end
+    subject{ @task }
+
+    should "not spy cmds that use the `dry_tree_run` opt" do
+      # scmd is in test mode so we can test its spy and see if it was run
+      # called; if scmd was run then as far as dk is concerned it ran the cmd
+      assert_instance_of Dk::Local::Cmd, @task.dry_tree_run_cmd
+      assert_true @task.dry_tree_run_cmd.scmd.run_called?
+      # check that the first local cmd of the remote cmd was run
+      assert_instance_of Dk::Remote::Cmd, @task.dry_tree_run_ssh
+      assert_true @task.dry_tree_run_ssh.local_cmds.values.first.scmd.start_called?
+    end
+
+    should "spy cmds that don't use the `dry_tree_run` opt" do
+      assert_instance_of Dk::Local::CmdSpy, @task.regular_cmd
+      assert_true @task.regular_cmd.run_called?
+      assert_instance_of Dk::Remote::CmdSpy, @task.regular_ssh
+      assert_true @task.regular_ssh.run_called?
+    end
+
+    should "spy cmds that are stubbed and use the `dry_tree_run` opt" do
+      assert_instance_of Dk::Local::CmdSpy, @task.stubbed_cmd
+      assert_true @task.stubbed_cmd.run_called?
+      assert_instance_of Dk::Remote::CmdSpy, @task.stubbed_ssh
+      assert_true @task.stubbed_ssh.run_called?
+    end
+
+  end
+
+  class DTRTreeRunnerSystemTests < DryTreeRunSystemTests
+    desc "TreeRunner"
+    setup do
+      @runner = Dk::TreeRunner.new(@dk_config, StringIO.new)
+
+      # stub a cmd/ssh using `dry_tree_run` so we can test that the stub takes
+      # precedence over the `dry_tree_run` opt
+      @runner.stub_cmd(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+        s.stdout = Factory.string
+      end
+      @runner.stub_ssh(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+        s.stdout = Factory.string
+      end
+
+      @task = @runner.run(@task_class, @params)
+    end
+    subject{ @task }
+
+    should "not spy cmds that use the `dry_tree_run` opt" do
+      # scmd is in test mode so we can test its spy and see if it was run
+      # called; if scmd was run then as far as dk is concerned it ran the cmd
+      assert_instance_of Dk::Local::Cmd, @task.dry_tree_run_cmd
+      assert_true @task.dry_tree_run_cmd.scmd.run_called?
+      # check that the first local cmd of the remote cmd was run
+      assert_instance_of Dk::Remote::Cmd, @task.dry_tree_run_ssh
+      assert_true @task.dry_tree_run_ssh.local_cmds.values.first.scmd.start_called?
+    end
+
+    should "spy cmds that don't use the `dry_tree_run` opt" do
+      assert_instance_of Dk::Local::CmdSpy, @task.regular_cmd
+      assert_true @task.regular_cmd.run_called?
+      assert_instance_of Dk::Remote::CmdSpy, @task.regular_ssh
+      assert_true @task.regular_ssh.run_called?
+    end
+
+    should "spy cmds that are stubbed and use the `dry_tree_run` opt" do
+      assert_instance_of Dk::Local::CmdSpy, @task.stubbed_cmd
+      assert_true @task.stubbed_cmd.run_called?
+      assert_instance_of Dk::Remote::CmdSpy, @task.stubbed_ssh
+      assert_true @task.stubbed_ssh.run_called?
+    end
+
+  end
+
+  class DTRTestRunnerSystemTests < DryTreeRunSystemTests
+    desc "TestRunner"
+    setup do
+      @runner = Dk::TestRunner.new(:logger => @logger)
+      @runner.task_class = @task_class
+
+      # stub a cmd/ssh using `dry_tree_run` so we can test that the stub takes
+      # precedence over the `dry_tree_run` opt
+      @runner.stub_cmd(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+        s.stdout = Factory.string
+      end
+      @runner.stub_ssh(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+        s.stdout = Factory.string
+      end
+
+      @task = @runner.run(@params)
+    end
+    subject{ @task }
+
+    should "spy all cmds/ssh regardless of the `dry_tree_run` opt" do
+      assert_instance_of Dk::Local::CmdSpy, @task.dry_tree_run_cmd
+      assert_true @task.dry_tree_run_cmd.run_called?
+      assert_instance_of Dk::Local::CmdSpy, @task.regular_cmd
+      assert_true @task.regular_cmd.run_called?
+      assert_instance_of Dk::Local::CmdSpy, @task.stubbed_cmd
+      assert_true @task.stubbed_cmd.run_called?
+
+      assert_instance_of Dk::Remote::CmdSpy, @task.dry_tree_run_ssh
+      assert_true @task.dry_tree_run_cmd.run_called?
+      assert_instance_of Dk::Remote::CmdSpy, @task.regular_ssh
+      assert_true @task.regular_ssh.run_called?
+      assert_instance_of Dk::Remote::CmdSpy, @task.stubbed_ssh
+      assert_true @task.stubbed_ssh.run_called?
+    end
+
+  end
+
+end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -26,14 +26,12 @@ class Dk::CLI
     setup do
       @kernel_spy = KernelSpy.new
 
-      @scmd_test_mode = ENV['SCMD_TEST_MODE']
       Dk.reset
       ENV['DK_CONFIG'] = ROOT_PATH.join('test/support/config/tasks.rb').to_s
       @cli = Dk::CLI.new(@kernel_spy)
     end
     teardown do
       Dk.reset
-      ENV['SCMD_TEST_MODE'] = @scmd_test_mode
     end
     subject{ @cli }
 
@@ -61,10 +59,8 @@ class Dk::CLI
       @cli.run('cli-test-task', 'cli-other-task')
     end
 
-    should "build live runner, not disable scmd and run the named tasks and exit" do
+    should "build live runner and run the named tasks and exit" do
       assert_equal [Dk.config],     @runner_init_with
-      assert_equal @scmd_test_mode, ENV['SCMD_TEST_MODE']
-
       assert_equal 2, @runner_runs.size
       assert_equal [CLITestTask],  @runner_runs.first
       assert_equal [CLIOtherTask], @runner_runs.last
@@ -89,9 +85,8 @@ class Dk::CLI
       @cli.run('cli-test-task', '--dry-run')
     end
 
-    should "build dry runner, disable scmd and run the named task and exit" do
+    should "build dry runner and run the named task and exit" do
       assert_equal [Dk.config],   @runner_init_with
-      assert_equal '1',           ENV['SCMD_TEST_MODE']
       assert_equal [CLITestTask], @runner_run_with
 
       assert_equal 0, @kernel_spy.exit_status
@@ -114,9 +109,8 @@ class Dk::CLI
       @cli.run('cli-test-task', '--tree')
     end
 
-    should "build tree runner, disable scmd and run the named task and exit" do
+    should "build tree runner and run the named task and exit" do
       assert_equal [Dk.config, @kernel_spy], @runner_init_with
-      assert_equal '1',                      ENV['SCMD_TEST_MODE']
       assert_equal [CLITestTask],            @runner_run_with
 
       assert_equal 0, @kernel_spy.exit_status

--- a/test/unit/dry_runner_tests.rb
+++ b/test/unit/dry_runner_tests.rb
@@ -16,6 +16,10 @@ class Dk::DryRunner
       assert_true subject < Dk::ConfigRunner
     end
 
+    should "have the stubs" do
+      assert_includes Dk::HasTheStubs, subject
+    end
+
   end
 
 end

--- a/test/unit/has_the_stubs_tests.rb
+++ b/test/unit/has_the_stubs_tests.rb
@@ -1,0 +1,333 @@
+require 'assert'
+require 'dk/has_the_stubs'
+
+require 'dk/local'
+require 'dk/remote'
+
+module Dk::HasTheStubs
+
+  class UnitTests < Assert::Context
+    desc "Dk::HasTheStubs"
+    setup do
+      @module = Dk::HasTheStubs
+    end
+    subject{ @module }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+  end
+
+  class MixinTests < UnitTests
+    desc "mixed in"
+    setup do
+      @class = Class.new do
+        include Dk::HasTheStubs
+
+        def has_the_stubs_build_local_cmd(cmd_str, given_opts)
+          BuiltCmd.new(cmd_str, given_opts)
+        end
+
+        def has_the_stubs_build_remote_cmd(cmd_str, ssh_opts)
+          BuiltCmd.new(cmd_str, ssh_opts)
+        end
+      end
+    end
+    subject{ @class }
+
+  end
+
+  class InitTests < MixinTests
+    desc "when init"
+    setup do
+      @cmd_str   = Factory.string
+      @cmd_input = Factory.string
+      @cmd_opts  = { Factory.string => Factory.string }
+
+      @given_ssh_opts = Factory.ssh_cmd_opts
+      @ssh_opts       = { :hosts => Factory.hosts }
+
+      @stub_block = Proc.new{ |s| Factory.string }
+
+      @instance = @class.new
+    end
+    subject{ @instance }
+
+    should have_imeths :stub_cmd, :unstub_cmd, :unstub_all_cmds
+    should have_imeths :stub_ssh, :unstub_ssh, :unstub_all_ssh
+
+    should "allow stubbing cmds" do
+      assert_equal 0, subject.instance_eval{ local_cmd_spy_blocks.size }
+
+      subject.stub_cmd(@cmd_str, &@stub_block)
+      assert_equal 1, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, nil]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+
+      subject.stub_cmd(@cmd_str, @cmd_input, &@stub_block)
+      assert_equal 2, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, nil]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+
+      subject.stub_cmd(@cmd_str, @cmd_opts, &@stub_block)
+      assert_equal 3, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, @cmd_opts]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+
+      subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
+      assert_equal 4, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, @cmd_opts]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+    end
+
+    should "allow unstubbing cmds" do
+      subject.stub_cmd(@cmd_str, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_input, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_opts, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
+
+      assert_equal 4, subject.instance_eval{ local_cmd_spy_blocks.size }
+
+      subject.unstub_cmd(@cmd_str)
+      assert_equal 3, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, nil]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+
+      subject.unstub_cmd(@cmd_str, @cmd_input)
+      assert_equal 2, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, nil]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+
+      subject.unstub_cmd(@cmd_str, @cmd_opts)
+      assert_equal 1, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, @cmd_opts]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+
+      subject.unstub_cmd(@cmd_str, @cmd_input, @cmd_opts)
+      assert_equal 0, subject.instance_eval{ local_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, @cmd_opts]
+      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+    end
+
+    should "not error unstubbing cmds that aren't stubbed" do
+      assert_nothing_raised{ subject.unstub_cmd(@cmd_str) }
+      assert_nothing_raised{ subject.unstub_cmd(@cmd_str, @cmd_input) }
+      assert_nothing_raised{ subject.unstub_cmd(@cmd_str, @cmd_opts) }
+      assert_nothing_raised{ subject.unstub_cmd(@cmd_str, @cmd_input, @cmd_opts) }
+    end
+
+    should "allow unstubbing all cmds" do
+      subject.stub_cmd(@cmd_str, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_input, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_opts, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
+
+      assert_equal 4, subject.instance_eval{ local_cmd_spy_blocks.size }
+      subject.unstub_all_cmds
+      assert_equal 0, subject.instance_eval{ local_cmd_spy_blocks.size }
+    end
+
+    should "allow stubbing ssh" do
+      assert_equal 0, subject.instance_eval{ remote_cmd_spy_blocks.size }
+
+      subject.stub_ssh(@cmd_str, &@stub_block)
+      assert_equal 1, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, nil]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+
+      subject.stub_ssh(@cmd_str, @cmd_input, &@stub_block)
+      assert_equal 2, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, nil]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+
+      subject.stub_ssh(@cmd_str, @given_ssh_opts, &@stub_block)
+      assert_equal 3, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, @given_ssh_opts]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+
+      subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
+      assert_equal 4, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, @given_ssh_opts]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_same @stub_block, spy_block
+    end
+
+    should "allow unstubbing ssh" do
+      subject.stub_ssh(@cmd_str, &@stub_block)
+      subject.stub_ssh(@cmd_str, @cmd_input, &@stub_block)
+      subject.stub_ssh(@cmd_str, @given_ssh_opts, &@stub_block)
+      subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
+
+      assert_equal 4, subject.instance_eval{ remote_cmd_spy_blocks.size }
+
+      subject.unstub_ssh(@cmd_str)
+      assert_equal 3, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, nil]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+
+      subject.unstub_ssh(@cmd_str, @cmd_input)
+      assert_equal 2, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, nil]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+
+      subject.unstub_ssh(@cmd_str, @given_ssh_opts)
+      assert_equal 1, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, nil, @given_ssh_opts]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+
+      subject.unstub_ssh(@cmd_str, @cmd_input, @given_ssh_opts)
+      assert_equal 0, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      exp_key   = [@cmd_str, @cmd_input, @given_ssh_opts]
+      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      assert_nil spy_block
+    end
+
+    should "not error unstubbing ssh that aren't stubbed" do
+      assert_nothing_raised{ subject.unstub_ssh(@cmd_str) }
+      assert_nothing_raised{ subject.unstub_ssh(@cmd_str, @cmd_input) }
+      assert_nothing_raised{ subject.unstub_ssh(@cmd_str, @given_ssh_opts) }
+      assert_nothing_raised{ subject.unstub_ssh(@cmd_str, @cmd_input, @given_ssh_opts) }
+    end
+
+    should "allow unstubbing all ssh" do
+      subject.stub_ssh(@cmd_str, &@stub_block)
+      subject.stub_ssh(@cmd_str, @cmd_input, &@stub_block)
+      subject.stub_ssh(@cmd_str, @given_ssh_opts, &@stub_block)
+      subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
+
+      assert_equal 4, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      subject.unstub_all_ssh
+      assert_equal 0, subject.instance_eval{ remote_cmd_spy_blocks.size }
+    end
+
+    # test the `Runner` interface that this overwrites, these are private
+    # methods but since they overwrite the runner's interface we want to test
+    # them as if they were public methods
+
+    should "use stubs with `build_local_cmd`" do
+      cmd_str, cmd_input, cmd_opts = @cmd_str, @cmd_input, @cmd_opts
+
+      subject.stub_cmd(@cmd_str){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval{ build_local_cmd(cmd_str, nil, nil) }
+      assert_false spy.success?
+
+      subject.unstub_all_cmds
+      subject.stub_cmd(@cmd_str, @cmd_input){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval{ build_local_cmd(cmd_str, cmd_input, nil) }
+      assert_false spy.success?
+
+      subject.unstub_all_cmds
+      subject.stub_cmd(@cmd_str, @cmd_opts){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval{ build_local_cmd(cmd_str, nil, cmd_opts) }
+      assert_false spy.success?
+
+      subject.unstub_all_cmds
+      subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval{ build_local_cmd(cmd_str, cmd_input, cmd_opts) }
+      assert_false spy.success?
+    end
+
+    should "cache stubbed local cmd spies using `build_local_cmd`" do
+      subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
+
+      cmd_str, cmd_input, cmd_opts = @cmd_str, @cmd_input, @cmd_opts
+      spy    = subject.instance_eval{ build_local_cmd(cmd_str, cmd_input, cmd_opts) }
+      result = subject.instance_eval{ build_local_cmd(cmd_str, cmd_input, cmd_opts) }
+      assert_same spy, result
+    end
+
+    should "remove cached stubbed local cmd spies when unstubbing" do
+      subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
+      cmd_str, cmd_input, cmd_opts = @cmd_str, @cmd_input, @cmd_opts
+      spy = subject.instance_eval{ build_local_cmd(cmd_str, cmd_input, cmd_opts) }
+
+      subject.unstub_all_cmds
+      result = subject.instance_eval{ build_local_cmd(cmd_str, cmd_input, cmd_opts) }
+      assert_not_same spy, result
+    end
+
+    should "use stubs with `build_remote_cmd`" do
+      cmd_str, cmd_input, given_opts, ssh_opts = @cmd_str, @cmd_input, @given_ssh_opts, @ssh_opts
+
+      subject.stub_ssh(@cmd_str){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval{ build_remote_cmd(cmd_str, nil, nil, ssh_opts) }
+      assert_false spy.success?
+
+      subject.unstub_all_ssh
+      subject.stub_ssh(@cmd_str, @cmd_input){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval do
+        build_remote_cmd(cmd_str, cmd_input, nil, ssh_opts)
+      end
+      assert_false spy.success?
+
+      subject.unstub_all_ssh
+      subject.stub_ssh(@cmd_str, @given_ssh_opts){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval do
+        build_remote_cmd(cmd_str, nil, given_opts, ssh_opts)
+      end
+      assert_false spy.success?
+
+      subject.unstub_all_ssh
+      subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts){ |s| s.exitstatus = 1 }
+      spy = subject.instance_eval do
+        build_remote_cmd(cmd_str, cmd_input, given_opts, ssh_opts)
+      end
+      assert_false spy.success?
+    end
+
+    should "cache stubbed remote cmd spies using `build_remote_cmd`" do
+      subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
+
+      cmd_str, cmd_input, given_opts, ssh_opts = @cmd_str, @cmd_input, @given_ssh_opts, @ssh_opts
+      spy = subject.instance_eval do
+        build_remote_cmd(cmd_str, cmd_input, given_opts, ssh_opts)
+      end
+      result = subject.instance_eval do
+        build_remote_cmd(cmd_str, cmd_input, given_opts, ssh_opts)
+      end
+      assert_same spy, result
+    end
+
+    should "remove cached stubbed ssh spies when unstubbing" do
+      subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
+      cmd_str, cmd_input, given_opts, ssh_opts = @cmd_str, @cmd_input, @given_ssh_opts, @ssh_opts
+      spy = subject.instance_eval do
+        build_remote_cmd(cmd_str, cmd_input, given_opts, ssh_opts)
+      end
+
+      subject.unstub_all_ssh
+      result = subject.instance_eval do
+        build_remote_cmd(cmd_str, cmd_input, given_opts, ssh_opts)
+      end
+      assert_not_same spy, result
+    end
+
+    should "defer to `has_the_stubs_build_remote_cmd` when cmd isn't stubbed" do
+      cmd_str, cmd_input, given_opts, ssh_opts = @cmd_str, @cmd_input, @given_ssh_opts, @ssh_opts
+      result = subject.instance_eval do
+        build_remote_cmd(cmd_str, cmd_input, given_opts, ssh_opts)
+      end
+      assert_equal BuiltCmd.new(cmd_str, ssh_opts), result
+    end
+
+  end
+
+  BuiltCmd = Struct.new(:cmd_str, :opts)
+
+end
+

--- a/test/unit/local_tests.rb
+++ b/test/unit/local_tests.rb
@@ -116,14 +116,6 @@ module Dk::Local
       assert_equal [@cmd_str, { :env => opts[:env] }], @scmd_new_called_with
     end
 
-    should "build an Scmd::Command (to bypass test mode spying) if the dry/tree run option given" do
-      opts = { :dry_tree_run => true }
-      cmd  = @cmd_class.new(@cmd_str, opts)
-
-      exp = [@cmd_str, { :env => nil }]
-      assert_equal exp, @scmd_cmd_new_called_with
-    end
-
   end
 
   class CmdSpyTests < UnitTests


### PR DESCRIPTION
This pulls the stubbing logic out of the `TestRunner` and adds it
to the mixin `HasTheStubs`. The mixin is added to both the
`TestRunner` and the `DryRunner` so that they can both use stubs.
This is setup for adding dry/tree stubs to the config and using
them when a running tasks using a dry or tree runner.

This caused the `dry_tree_run` opt to be reworked because using
stubbing logic from the `TestRunner` caused it to no longer run
the cmds. The stubbing logic was modified to allow the runners to
define how `HasTheStubs` should build a cmd when the cmd isn't
stubbed. For the test runner it builds a spy for the cmd anyway
because we never want to run a cmd with the test runner. For the
dry and tree runner they will check if the `dry_tree_run` opt is
used. If so, they will build a real cmd/ssh otherwise they will use
a spy. This removes all of the old logic for handling
`dry_tree_run` and also removes setting scmd's test mode env var as
its no longer needed to keep the dry/tree runner from running cmds.

Removing setting scmd's test mode env var revealed an issue with
using scmd's `CommandSpy`. It previously didn't work if the env
var wasn't set. This updates to the latest version of scmd so that
the `CommandSpy` can be used without having to set the env var.

This also moves the stub tests from the `TestRunner` tests and
reworks them to be system tests for `HasTheStubs`. This ensures
that they work with the `TestRunner`, `DryRunner` and `TreeRunner`.
This also expands them to ensure that they work with all possible
combinations of args (cmd str only, cmd str and input, cmd str and
opts or all of them).

This also adds unit tests for the `HasTheStubs` mixin. These test
the public stub cmds but also test the private `build_local_cmd`
and `build_remote_cmd` methods. These are tested even though they
are private because they are the methods that integrate with the
runners. This ensures they work as expected and that they should
integrate with the runners as expected.

Finally, this adds system tests for the `dry_tree_run` logic to
examine how it behaves with all of the different runners. This
ensures that we don't accidentally lose its behavior with future
changes.

@kellyredding - Ready for review.
