### PR TITLE
Add storing dry/tree runner stubs to `Config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,28 @@ Use the `task` method to configure tasks that are runnable via the CLI.  This al
 
 **Note**: only tasks configured using this method will be runnable from the CLI.
 
+##### `stub_dry_tree_cmd`, `stub_dry_tree_ssh`
+
+```ruby
+require 'dk'
+
+Dk.configure do
+
+  stub_dry_tree_cmd("ls -la") do |spy| # spy is a Local::CmdSpy
+    spy.stdout = "..."
+  end
+
+  stub_dry_tree_ssh("ls -la") do |spy| # spy is a Remote::CmdSpy
+    spy.exitstatus = 1 # simulare the ssh call failing
+  end
+
+  # ...
+
+end
+```
+
+Use the `stub_dry_tree_cmd` and `stub_dry_tree_ssh` methods to add cmd and ssh stubs when using `--dry-run` or `--tree`. This can be used to control the stdout, stderr or exitstatus of a command. This is useful when a task uses the output of one command for another command or when the task does different logic depending on if a command succeeds or fails.
+
 ### Task
 
 #### Helper Methods

--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -25,12 +25,13 @@ module Dk
     DEFAULT_LOG_PATTERN      = "%m\n".freeze
     DEFAULT_LOG_FILE_PATTERN = '[%d %-5l] : %m\n'.freeze
     DEFAULT_STDOUT_LOG_LEVEL = 'info'.freeze
+    DEFAULT_STUBS            = [].freeze
     FILE_LOG_LEVEL           = 'debug'.freeze
 
     attr_reader :init_procs, :params
     attr_reader :before_callbacks, :prepend_before_callbacks
     attr_reader :after_callbacks, :prepend_after_callbacks
-    attr_reader :tasks
+    attr_reader :tasks, :dry_tree_cmd_stubs, :dry_tree_ssh_stubs
 
     def initialize
       @init_procs               = DEFAULT_INIT_PROCS.dup
@@ -47,6 +48,8 @@ module Dk
       @log_pattern              = DEFAULT_LOG_PATTERN
       @log_file                 = nil
       @log_file_pattern         = DEFAULT_LOG_FILE_PATTERN
+      @dry_tree_cmd_stubs       = DEFAULT_STUBS.dup
+      @dry_tree_ssh_stubs       = DEFAULT_STUBS.dup
     end
 
     def init
@@ -131,6 +134,18 @@ module Dk
       @log_file_pattern
     end
 
+    def stub_dry_tree_cmd(cmd_str, *args, &block)
+      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+      input      = args.last
+      @dry_tree_cmd_stubs << DryTreeStub.new(cmd_str, input, given_opts, block)
+    end
+
+    def stub_dry_tree_ssh(cmd_str, *args, &block)
+      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+      input      = args.last
+      @dry_tree_ssh_stubs << DryTreeStub.new(cmd_str, input, given_opts, block)
+    end
+
     # private - intended for internal use only
 
     def dk_logger_stdout_output_name
@@ -176,6 +191,8 @@ module Dk
       end
 
     end
+
+    DryTreeStub = Struct.new(:cmd_str, :input, :given_opts, :block)
 
   end
 


### PR DESCRIPTION
This updates the `Config` to allow storing dry/tree runner stubs.
These will be used to add stubs to the runners when they are built.
This will allow a cmds output or exitstatus to be changed from the
default when a dry and tree runner runs. Specifically this is
needed when a task uses a cmds output or exitstatus to change the
flow of a task.

This adds DSL methods to the `Config` for adding cmd and ssh stubs.
These are simply stored on the `Config` and in a future effort they
will be applied to a dry/tree runner. This will allow a dk gem or
app using dk to include stubs for cmds to ensure they can be used
with a dry or tree runner.

@kellyredding - Ready for review.
