### PR TITLE
have tasks log when they run

### DIFF
--- a/dk.gemspec
+++ b/dk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.2"])
 
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
   gem.add_dependency("scmd",        ["~> 3.0.2"])

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,3 +1,4 @@
+require 'benchmark'
 require 'set'
 require 'dk/config'
 require 'dk/has_set_param'
@@ -65,6 +66,12 @@ module Dk
     def log_debug(msg); self.logger.debug(msg); end # TODO: style up
     def log_error(msg); self.logger.error(msg); end # TODO: style up
 
+    def log_task_run(task_class, &run_block)
+      self.logger.info("> #{task_class} ...")
+      time = Benchmark.realtime(&run_block)
+      self.logger.info("  ... #{task_class} (#{self.pretty_run_time(time)})")
+    end
+
     def cmd(cmd_str, input, given_opts)
       build_and_run_local_cmd(cmd_str, input, given_opts)
     end
@@ -75,6 +82,14 @@ module Dk
 
     def has_run_task?(task_class)
       @has_run_task_classes.include?(task_class)
+    end
+
+    def pretty_run_time(raw_run_time)
+      if raw_run_time >= 1.0 # seconds
+        "#{raw_run_time / 60}:#{(raw_run_time % 60).to_s.rjust(2, '0')}s"
+      else
+        "#{(raw_run_time * 1000 * 10.0).round / 10.0}ms"
+      end
     end
 
     private

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -22,9 +22,11 @@ module Dk
       end
 
       def dk_run
-        self.dk_run_callbacks 'before'
-        catch(:halt){ self.run! }
-        self.dk_run_callbacks 'after'
+        @dk_runner.log_task_run(self.class) do
+          self.dk_run_callbacks 'before'
+          catch(:halt){ self.run! }
+          self.dk_run_callbacks 'after'
+        end
       end
 
       def run!

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -231,6 +231,17 @@ module Dk::Task
       assert_equal 11, @call_orders.runner_after_call_order
     end
 
+    should "log the task run with its runner" do
+      runner = test_runner(@task_class)
+
+      log_task_run_called_with = nil
+      Assert.stub(runner, :log_task_run){ |*args| log_task_run_called_with = args }
+      task = @task_class.new(runner)
+      task.dk_run
+
+      assert_equal [@task_class], log_task_run_called_with
+    end
+
   end
 
   class RunOnlyOnceTests < RunTests


### PR DESCRIPTION
This includes identifying the task class that is starting to run
and identifying when a task class finishes running (including the
formatted run time of the task).  This gives the user timing info
on their tasks and let's them know when any one task starts or
finishes so they are aware of the progress.

This is part of cleaning up and making the both the file and
stdout UX more friendly.

```
$ dk my-task
> MyTask ...
> MySubTask ...
  ... MySubTask (572.1ms)
  ... MyTask (0:02s)
$
```

Note: this also updates to the latest Assert which has a float
Factory bugfix needed for these tests.

@jcredding ready for review.
