### PR TITLE
style up the user task log messages

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -13,6 +13,9 @@ module Dk
     include Dk::HasSetParam
     include Dk::HasSSHOpts
 
+    TASK_START_LOG_PREFIX  = '> '.freeze
+    INDENTATION_LOG_PREFIX = '    '.freeze
+
     attr_reader :params, :logger
 
     def initialize(opts = nil)
@@ -62,14 +65,15 @@ module Dk
       check_run_once_and_build_and_run_task(task_class, params)
     end
 
-    def log_info(msg);  self.logger.info(msg);  end # TODO: style up
-    def log_debug(msg); self.logger.debug(msg); end # TODO: style up
-    def log_error(msg); self.logger.error(msg); end # TODO: style up
+    def log_info(msg);  self.logger.info(log_msg(1, msg)); end
+    def log_debug(msg); self.logger.debug(log_msg(1, msg)); end
+    def log_error(msg); self.logger.error(log_msg(1, msg)); end
 
     def log_task_run(task_class, &run_block)
-      self.logger.info("> #{task_class} ...")
+      self.logger.info ""
+      self.logger.info "#{TASK_START_LOG_PREFIX}#{task_class} ..."
       time = Benchmark.realtime(&run_block)
-      self.logger.info("  ... #{task_class} (#{self.pretty_run_time(time)})")
+      self.logger.info "... #{task_class} (#{self.pretty_run_time(time)})"
     end
 
     def cmd(cmd_str, input, given_opts)
@@ -93,6 +97,10 @@ module Dk
     end
 
     private
+
+    def log_msg(indentation_level, msg)
+      "#{INDENTATION_LOG_PREFIX*indentation_level}#{msg}"
+    end
 
     def check_run_once_and_build_and_run_task(task_class, params = nil)
       if task_class.run_only_once && self.has_run_task?(task_class)

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -26,6 +26,11 @@ class Dk::Runner
       assert_includes Dk::HasSSHOpts, subject
     end
 
+    should "know its log prefix values" do
+      assert_equal '> ',     subject::TASK_START_LOG_PREFIX
+      assert_equal '    ',   subject::INDENTATION_LOG_PREFIX
+    end
+
   end
 
   class InitTests < UnitTests
@@ -165,13 +170,16 @@ class Dk::Runner
       msg = Factory.string
 
       subject.log_info msg
-      assert_equal [msg], logger_info_called_with
+      exp = ["#{INDENTATION_LOG_PREFIX}#{msg}"]
+      assert_equal exp, logger_info_called_with
 
       subject.log_debug msg
-      assert_equal [msg], logger_debug_called_with
+      exp = ["#{INDENTATION_LOG_PREFIX}#{msg}"]
+      assert_equal exp, logger_debug_called_with
 
       subject.log_error msg
-      assert_equal [msg], logger_error_called_with
+      exp = ["#{INDENTATION_LOG_PREFIX}#{msg}"]
+      assert_equal exp, logger_error_called_with
     end
 
     should "log the start/finish of task runs, including their run time" do
@@ -185,8 +193,9 @@ class Dk::Runner
       subject.log_task_run(task_class){}
 
       exp = [
-        ["> #{task_class} ..."],
-        ["  ... #{task_class} (#{pretty_run_time})"]
+        [""],
+        ["#{TASK_START_LOG_PREFIX}#{task_class} ..."],
+        ["... #{task_class} (#{pretty_run_time})"]
       ]
       assert_equal exp, logger_info_calls
     end


### PR DESCRIPTION
This indents the log messages from tasks to help visually
distinguish them from the task start/finish log msgs.  This also
sets up a log msg indentation scheme that will be used for future
logging of cmd/ssh runs.

This is part of styling up the log output of our tasks.  Note:
this also modifies the task run log styles to include an
empty line before task runs and not indenting the task finish lines
to help better see each task run.

```
$ dk my-task
> MyTask ...
    running the sub task

> MySubTask ...
    running what the sub task does
... MySubTask (572.1ms)
... MyTask (0:02s)
$
```

@jcredding ready for review.  Are you cool with the 4-space indention and changes to the task logging (newline before task runs and not indenting task finish lines)?
