### PR TITLE
style up cmd/ssh log output; match styles in task/other logs

### DIFF
--- a/lib/dk/remote.rb
+++ b/lib/dk/remote.rb
@@ -26,17 +26,19 @@ module Dk::Remote
       @cmd_str       = cmd_str
 
       @local_cmds = @hosts.inject({}) do |cmds, host|
-        cmds[host] = local_cmd_or_spy_klass.new(
-          ssh_cmd_str(@cmd_str, host, @ssh_args, @host_ssh_args),
-          { :env          => opts[:env],
-            :dry_tree_run => opts[:dry_tree_run]
-          }
-        )
+        cmds[host] = local_cmd_or_spy_klass.new(self.ssh_cmd_str(host), {
+          :env          => opts[:env],
+          :dry_tree_run => opts[:dry_tree_run]
+        })
         cmds
       end
     end
 
     def to_s; self.cmd_str; end
+
+    def ssh_cmd_str(host)
+      build_ssh_cmd_str(@cmd_str, host, @ssh_args, @host_ssh_args)
+    end
 
     def run(input = nil)
       self.hosts.each{ |host| @local_cmds[host].scmd.start(input) }
@@ -65,7 +67,7 @@ module Dk::Remote
     end
 
     # escape everything properly; run in sh to ensure full profile is loaded
-    def ssh_cmd_str(cmd_str, host, args, host_args)
+    def build_ssh_cmd_str(cmd_str, host, args, host_args)
       Dk::Remote.ssh_cmd_str(cmd_str, host, args, host_args)
     end
 


### PR DESCRIPTION
So this was originally about just adding styled logs for cmd/ssh
runs.  It changed to not only do that, but also change up the log
scheme as well.  This issue is that as I added new log output, the
overall result didn't scale well - things just became noisier.

This switches the overall log scheme to include a left "buffer" of
5 chars plus an empty space.  This is used to signify things that
run: task starts/ends, cmds and sshs.  Everything else is indented
with empty spaces.  The goal here is to make things as readable
as possible.

This adds better logging for local/remote cmds.  It logs the cmd
str with its buffer identifier.  Remote cmds also log their fully
qualified cmd strs as debug and list out each host the cmd runs
on.  Both typs then print out the time the cmd took to run and any
cmd output is logged with the `>` prefix.  I chose this prefix
b/c it matches the markdown syntax for quote text.

```
$ dk my-task
***** MyTask ...
      running the sub task

***** MySubTask ...
      running what the sub task does
..... MySubTask (572.1ms)
[CMD] <some cmd str>
      (200.0ms)
      > cmd output line 1
      > cmd output line 2
[SSH] <some cmd str>
      ssh -o ...  <host> -- "sh -c \"<some cmd str>\""
      [host1]
      [host2]
      (913.5ms)
..... MyTask (0:02s)
$
```

@jcredding ready for review.  Does this all make sense and look good to you?
