### PR TITLE
Update `DryRunner`, apply dry tree stubs from `Config` on init

### DIFF
--- a/lib/dk/dry_runner.rb
+++ b/lib/dk/dry_runner.rb
@@ -8,6 +8,16 @@ module Dk
 
     # run with disabled cmds, just log actions, but run all sub-tasks
 
+    def initialize(config, *args)
+      super(config, *args)
+      config.dry_tree_cmd_stubs.each do |s|
+        self.stub_cmd(s.cmd_str, s.input, s.given_opts, &s.block)
+      end
+      config.dry_tree_ssh_stubs.each do |s|
+        self.stub_ssh(s.cmd_str, s.input, s.given_opts, &s.block)
+      end
+    end
+
     private
 
     def has_the_stubs_build_local_cmd(cmd_str, given_opts)

--- a/lib/dk/has_the_stubs.rb
+++ b/lib/dk/has_the_stubs.rb
@@ -19,21 +19,27 @@ module Dk
       def stub_cmd(cmd_str, *args, &block)
         given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
         input      = args.last
-        local_cmd_spy_blocks[cmd_spy_key(cmd_str, input, given_opts)] = block
+
+        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
+        local_cmd_stub_blocks[key] = block
       end
 
       def unstub_cmd(cmd_str, *args)
         given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
         input      = args.last
 
-        key = cmd_spy_key(cmd_str, input, given_opts)
-        local_cmd_spy_blocks.delete(key)
+        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
+        local_cmd_stub_blocks.delete(key)
         local_cmd_spies.delete(key)
       end
 
       def unstub_all_cmds
-        local_cmd_spy_blocks.clear
+        local_cmd_stub_blocks.clear
         local_cmd_spies.clear
+      end
+
+      def local_cmd_stubs
+        local_cmd_stub_blocks.map{ |key, block| Stub.new(*(key + [block])) }
       end
 
       # ssh stub API
@@ -41,21 +47,27 @@ module Dk
       def stub_ssh(cmd_str, *args, &block)
         given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
         input      = args.last
-        remote_cmd_spy_blocks[cmd_spy_key(cmd_str, input, given_opts)] = block
+
+        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
+        remote_cmd_stub_blocks[key] = block
       end
 
       def unstub_ssh(cmd_str, *args)
         given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
         input      = args.last
 
-        key = cmd_spy_key(cmd_str, input, given_opts)
-        remote_cmd_spy_blocks.delete(key)
+        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
+        remote_cmd_stub_blocks.delete(key)
         remote_cmd_spies.delete(key)
       end
 
       def unstub_all_ssh
-        remote_cmd_spy_blocks.clear
+        remote_cmd_stub_blocks.clear
         remote_cmd_spies.clear
+      end
+
+      def remote_cmd_stubs
+        remote_cmd_stub_blocks.map{ |key, block| Stub.new(*(key + [block])) }
       end
 
       private
@@ -64,8 +76,8 @@ module Dk
       # cached spy), otherwise let the runner decide how to handle the local
       # cmd
       def build_local_cmd(cmd_str, input, given_opts)
-        key = cmd_spy_key(cmd_str, input, given_opts)
-        if (block = local_cmd_spy_blocks[key])
+        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
+        if (block = local_cmd_stub_blocks[key])
           local_cmd_spies[key] ||= Local::CmdSpy.new(cmd_str, given_opts).tap(&block)
         else
           has_the_stubs_build_local_cmd(cmd_str, given_opts)
@@ -76,13 +88,8 @@ module Dk
         raise NotImplementedError
       end
 
-      def local_cmd_spies
-        @local_cmd_spies ||= {}
-      end
-
-      def local_cmd_spy_blocks
-        @local_cmd_spy_blocks ||= {}
-      end
+      def local_cmd_stub_blocks; @local_cmd_stub_blocks ||= {}; end
+      def local_cmd_spies;       @local_cmd_spies       ||= {}; end
 
       # if the cmd is stubbed, build a spy and apply the stub (or return the
       # cached spy), otherwise let the runner decide how to handle the remote
@@ -90,8 +97,8 @@ module Dk
       # calling ssh cmds with the same opts but also allows building a valid
       # remote cmd that has an ssh host
       def build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
-        key = cmd_spy_key(cmd_str, input, given_opts)
-        if (block = remote_cmd_spy_blocks[key])
+        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
+        if (block = remote_cmd_stub_blocks[key])
           remote_cmd_spies[key] ||= Remote::CmdSpy.new(cmd_str, ssh_opts).tap(&block)
         else
           has_the_stubs_build_remote_cmd(cmd_str, ssh_opts)
@@ -102,19 +109,16 @@ module Dk
         raise NotImplementedError
       end
 
-      def remote_cmd_spies
-        @remote_cmd_spies ||= {}
-      end
+      def remote_cmd_stub_blocks; @remote_cmd_stub_blocks ||= {}; end
+      def remote_cmd_spies;       @remote_cmd_spies       ||= {}; end
 
-      def remote_cmd_spy_blocks
-        @remote_cmd_spy_blocks ||= {}
-      end
-
-      def cmd_spy_key(cmd_str, input, given_opts)
+      def has_the_stubs_cmd_key(cmd_str, input, given_opts)
         [cmd_str, input, given_opts]
       end
 
     end
+
+    Stub = Struct.new(:cmd_str, :input, :given_opts, :block)
 
   end
 

--- a/test/unit/dry_runner_tests.rb
+++ b/test/unit/dry_runner_tests.rb
@@ -1,7 +1,9 @@
 require 'assert'
 require 'dk/dry_runner'
 
+require 'dk/config'
 require 'dk/config_runner'
+require 'dk/has_the_stubs'
 
 class Dk::DryRunner
 
@@ -18,6 +20,48 @@ class Dk::DryRunner
 
     should "have the stubs" do
       assert_includes Dk::HasTheStubs, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @dk_config = Dk::Config.new
+      Factory.integer(3).times.each do
+        @dk_config.stub_dry_tree_cmd(Factory.string, Factory.string, {
+          Factory.string => Factory.string
+        }){ |s| Factory.string }
+      end
+      Factory.integer(3).times.each do
+        @dk_config.stub_dry_tree_ssh(Factory.string, Factory.string, {
+          Factory.string => Factory.string
+        }){ |s| Factory.string }
+      end
+
+      @runner = @runner_class.new(@dk_config)
+    end
+    subject{ @runner }
+
+    should "add cmd/ssh dry tree stubs from its config" do
+      @dk_config.dry_tree_cmd_stubs.each do |stub|
+        exp = Dk::HasTheStubs::Stub.new(
+          stub.cmd_str,
+          stub.input,
+          stub.given_opts,
+          stub.block
+        )
+        assert_includes exp, @runner.local_cmd_stubs
+      end
+      @dk_config.dry_tree_ssh_stubs.each do |stub|
+        exp = Dk::HasTheStubs::Stub.new(
+          stub.cmd_str,
+          stub.input,
+          stub.given_opts,
+          stub.block
+        )
+        assert_includes exp, @runner.remote_cmd_stubs
+      end
     end
 
   end

--- a/test/unit/has_the_stubs_tests.rb
+++ b/test/unit/has_the_stubs_tests.rb
@@ -54,34 +54,34 @@ module Dk::HasTheStubs
     end
     subject{ @instance }
 
-    should have_imeths :stub_cmd, :unstub_cmd, :unstub_all_cmds
-    should have_imeths :stub_ssh, :unstub_ssh, :unstub_all_ssh
+    should have_imeths :stub_cmd, :unstub_cmd, :unstub_all_cmds, :local_cmd_stubs
+    should have_imeths :stub_ssh, :unstub_ssh, :unstub_all_ssh, :remote_cmd_stubs
 
     should "allow stubbing cmds" do
-      assert_equal 0, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 0, subject.instance_eval{ local_cmd_stub_blocks.size }
 
       subject.stub_cmd(@cmd_str, &@stub_block)
-      assert_equal 1, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 1, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, nil]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
 
       subject.stub_cmd(@cmd_str, @cmd_input, &@stub_block)
-      assert_equal 2, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 2, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, nil]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
 
       subject.stub_cmd(@cmd_str, @cmd_opts, &@stub_block)
-      assert_equal 3, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 3, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, @cmd_opts]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
 
       subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
-      assert_equal 4, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 4, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, @cmd_opts]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
     end
 
@@ -91,30 +91,30 @@ module Dk::HasTheStubs
       subject.stub_cmd(@cmd_str, @cmd_opts, &@stub_block)
       subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
 
-      assert_equal 4, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 4, subject.instance_eval{ local_cmd_stub_blocks.size }
 
       subject.unstub_cmd(@cmd_str)
-      assert_equal 3, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 3, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, nil]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
 
       subject.unstub_cmd(@cmd_str, @cmd_input)
-      assert_equal 2, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 2, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, nil]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
 
       subject.unstub_cmd(@cmd_str, @cmd_opts)
-      assert_equal 1, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 1, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, @cmd_opts]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
 
       subject.unstub_cmd(@cmd_str, @cmd_input, @cmd_opts)
-      assert_equal 0, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 0, subject.instance_eval{ local_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, @cmd_opts]
-      spy_block = subject.instance_eval{ local_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ local_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
     end
 
@@ -131,36 +131,52 @@ module Dk::HasTheStubs
       subject.stub_cmd(@cmd_str, @cmd_opts, &@stub_block)
       subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
 
-      assert_equal 4, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 4, subject.instance_eval{ local_cmd_stub_blocks.size }
       subject.unstub_all_cmds
-      assert_equal 0, subject.instance_eval{ local_cmd_spy_blocks.size }
+      assert_equal 0, subject.instance_eval{ local_cmd_stub_blocks.size }
+    end
+
+    should "know its local cmd stubs" do
+      subject.stub_cmd(@cmd_str, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_input, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_opts, &@stub_block)
+      subject.stub_cmd(@cmd_str, @cmd_input, @cmd_opts, &@stub_block)
+
+      exp = Stub.new(@cmd_str, nil, nil, @stub_block)
+      assert_includes exp, subject.local_cmd_stubs
+      exp = Stub.new(@cmd_str, @cmd_input, nil, @stub_block)
+      assert_includes exp, subject.local_cmd_stubs
+      exp = Stub.new(@cmd_str, nil, @cmd_opts, @stub_block)
+      assert_includes exp, subject.local_cmd_stubs
+      exp = Stub.new(@cmd_str, @cmd_input, @cmd_opts, @stub_block)
+      assert_includes exp, subject.local_cmd_stubs
     end
 
     should "allow stubbing ssh" do
-      assert_equal 0, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 0, subject.instance_eval{ remote_cmd_stub_blocks.size }
 
       subject.stub_ssh(@cmd_str, &@stub_block)
-      assert_equal 1, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 1, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, nil]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
 
       subject.stub_ssh(@cmd_str, @cmd_input, &@stub_block)
-      assert_equal 2, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 2, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, nil]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
 
       subject.stub_ssh(@cmd_str, @given_ssh_opts, &@stub_block)
-      assert_equal 3, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 3, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, @given_ssh_opts]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
 
       subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
-      assert_equal 4, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 4, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, @given_ssh_opts]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_same @stub_block, spy_block
     end
 
@@ -170,30 +186,30 @@ module Dk::HasTheStubs
       subject.stub_ssh(@cmd_str, @given_ssh_opts, &@stub_block)
       subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
 
-      assert_equal 4, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 4, subject.instance_eval{ remote_cmd_stub_blocks.size }
 
       subject.unstub_ssh(@cmd_str)
-      assert_equal 3, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 3, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, nil]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
 
       subject.unstub_ssh(@cmd_str, @cmd_input)
-      assert_equal 2, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 2, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, nil]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
 
       subject.unstub_ssh(@cmd_str, @given_ssh_opts)
-      assert_equal 1, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 1, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, nil, @given_ssh_opts]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
 
       subject.unstub_ssh(@cmd_str, @cmd_input, @given_ssh_opts)
-      assert_equal 0, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 0, subject.instance_eval{ remote_cmd_stub_blocks.size }
       exp_key   = [@cmd_str, @cmd_input, @given_ssh_opts]
-      spy_block = subject.instance_eval{ remote_cmd_spy_blocks[exp_key] }
+      spy_block = subject.instance_eval{ remote_cmd_stub_blocks[exp_key] }
       assert_nil spy_block
     end
 
@@ -210,9 +226,25 @@ module Dk::HasTheStubs
       subject.stub_ssh(@cmd_str, @given_ssh_opts, &@stub_block)
       subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
 
-      assert_equal 4, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 4, subject.instance_eval{ remote_cmd_stub_blocks.size }
       subject.unstub_all_ssh
-      assert_equal 0, subject.instance_eval{ remote_cmd_spy_blocks.size }
+      assert_equal 0, subject.instance_eval{ remote_cmd_stub_blocks.size }
+    end
+
+    should "know its remote cmd stubs" do
+      subject.stub_ssh(@cmd_str, &@stub_block)
+      subject.stub_ssh(@cmd_str, @cmd_input, &@stub_block)
+      subject.stub_ssh(@cmd_str, @given_ssh_opts, &@stub_block)
+      subject.stub_ssh(@cmd_str, @cmd_input, @given_ssh_opts, &@stub_block)
+
+      exp = Stub.new(@cmd_str, nil, nil, @stub_block)
+      assert_includes exp, subject.remote_cmd_stubs
+      exp = Stub.new(@cmd_str, @cmd_input, nil, @stub_block)
+      assert_includes exp, subject.remote_cmd_stubs
+      exp = Stub.new(@cmd_str, nil, @given_ssh_opts, @stub_block)
+      assert_includes exp, subject.remote_cmd_stubs
+      exp = Stub.new(@cmd_str, @cmd_input, @given_ssh_opts, @stub_block)
+      assert_includes exp, subject.remote_cmd_stubs
     end
 
     # test the `Runner` interface that this overwrites, these are private


### PR DESCRIPTION
This updates the `DryRunner` to apply dry tree stubs from it's
`Config` when it is initialized. This is the last part of allowing
users to add dry/tree runner stubs when configuring dk so they can
use the `--dry-run` and `--tree` options when running a task that
uses cmds output or exitstatus to change its flow.

The `DryRunner` now looks at its config's dry tree stubs and for
each of them it adds it's own stubs that match. This makes it so
a dry or tree runner will always use any stubs that are configured
on dk.

This also updates `HasTheStubs` to provide a `local_cmd_stubs` and
`remote_cmd_stubs` methods for testing and debugging. These can be
used to easily check the stubs that are configured on a runner.
This was noticed while implementing the `DryRunner` unit tests and
realizing it would require checking private methods and knowing
a lot of details about how `HasTheStubs` stores stubs.

Finally, this renames a few methods in `HasTheStubs`. The hash that
stores the blocks from the stub methods was renamed from "spy
blocks" to "stub blocks" since they come from the stub methods and
represent what cmds have been stubbed. This is more consistent with
the new public method that return `Stub` structs (we build `Stub`
structs from the stub blocks). The `cmd_spy_key` method was also
renamed to `has_the_stubs_key`. This is a more generic name since
it is used to key both the cmd spies and the stub blocks.

Closes #43

@kellyredding - Ready for review.
