### PR TITLE
add debug log entries at the start of new CLI runs

### DIFF
--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -63,6 +63,7 @@ module Dk
       @config.stdout_log_level('debug') if @clirb.opts['verbose']
 
       runner = get_runner(@config, @clirb.opts)
+      runner.log_cli_run(args.join(' '))
       @clirb.args.each{ |task_name| runner.run(@config.task(task_name)) }
     end
 

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -80,6 +80,13 @@ module Dk
       self.logger.info "#{TASK_END_LOG_PREFIX}#{task_class} (#{self.pretty_run_time(time)})"
     end
 
+    def log_cli_run(cli_argv)
+      15.times{ self.logger.debug "" }
+      self.logger.debug "===================================="
+      self.logger.debug ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `#{cli_argv}`"
+      self.logger.debug "===================================="
+    end
+
     def cmd(cmd_str, input, given_opts)
       build_and_run_local_cmd(cmd_str, input, given_opts)
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -53,7 +53,8 @@ class Dk::Runner
     should have_imeths :task_callbacks, :task_callback_task_classes
     should have_imeths :add_task_callback
     should have_imeths :run, :run_task
-    should have_imeths :log_info, :log_debug, :log_error, :log_task_run
+    should have_imeths :log_info, :log_debug, :log_error
+    should have_imeths :log_task_run, :log_cli_run
     should have_imeths :cmd, :ssh
     should have_imeths :has_run_task?, :pretty_run_time
 
@@ -203,6 +204,21 @@ class Dk::Runner
         ["#{TASK_END_LOG_PREFIX}#{task_class} (#{pretty_run_time})"]
       ]
       assert_equal exp, logger_info_calls
+    end
+
+    should "log the start of CLI runs" do
+      logger_debug_calls = []
+      Assert.stub(@args[:logger], :debug){ |*args| logger_debug_calls << args }
+
+      cli_argv = Factory.string
+      subject.log_cli_run(cli_argv)
+
+      exp = 15.times.map{ [""] } + [
+        ["===================================="],
+        [">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `#{cli_argv}`"],
+        ["===================================="]
+      ]
+      assert_equal exp, logger_debug_calls
     end
 
     should "know if it has run a task or not" do


### PR DESCRIPTION
The idea here is to visually space out CLI runs in log files. Log
files (and stdout w/ the `--verbose` flag) log at the debug level
and will show these log entries.  It is composed of 15 empty lines
plus some header lines that include the run's cli argv.

```
$ dk my-task --verbose















====================================
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `my-task --verbose`
====================================

***** MyTask ...
      running the sub task

***** MySubTask ...
      running what the sub task does
..... MySubTask (572.1ms)
[CMD] <some cmd str>
      (200.0ms)
      > cmd output line 1
      > cmd output line 2
[SSH] <some cmd str>
      ssh -o ...  <host> -- "sh -c \"<some cmd str>\""
      [host1]
      [host2]
      (913.5ms)
..... MyTask (0:02s)
$
```

@jcredding ready for review.
