### PR TITLE
add ansi styled log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,15 @@ end
 
 Use the `log_*` helpers to log information as the task is running.  Each corresponds to a logger level.  The CLI logs to stdout on the INFO level by default.  When run in verbose mode, it logs to stdout on the DEBUG level.  If an optional log file has been configured, the CLI will log to the file on DEBUG level regardless of any verbose mode setting.
 
+You can optionally style your log messages:
+
+```ruby
+log_info "my message", :red, :on_white
+log_info "my " + Dk::Ansi.styled_msg("special", :bold, :blue) + " message"
+```
+
+See `Dk::Ansi::CODES.keys` for a list of available style names.
+
 #### Task Descriptions
 
 ```ruby

--- a/lib/dk/ansi.rb
+++ b/lib/dk/ansi.rb
@@ -1,0 +1,98 @@
+module Dk
+
+  module Ansi
+
+    def self.styled_msg(msg, *styles)
+      code = self.code_for(*styles)
+      return msg if code.empty?
+      code + msg + self.code_for(:reset)
+    end
+
+    def self.code_for(*style_names)
+      style_names.map{ |n| "\e[#{CODES[n]}m" if CODES.key?(n) }.compact.join('')
+    end
+
+    # Table of supported styles/codes (http://en.wikipedia.org/wiki/ANSI_escape_code)
+
+    CODES = {
+      :clear            => 0,
+      :reset            => 0,
+      :bright           => 1,
+      :bold             => 1,
+      :faint            => 2,
+      :dark             => 2,
+      :italic           => 3,
+      :underline        => 4,
+      :underscore       => 4,
+      :blink            => 5,
+      :slow_blink       => 5,
+      :rapid            => 6,
+      :rapid_blink      => 6,
+      :invert           => 7,
+      :inverse          => 7,
+      :reverse          => 7,
+      :negative         => 7,
+      :swap             => 7,
+      :conceal          => 8,
+      :concealed        => 8,
+      :hide             => 9,
+      :strike           => 9,
+
+      :default_font     => 10,
+      :font_default     => 10,
+      :font0            => 10,
+      :font1            => 11,
+      :font2            => 12,
+      :font3            => 13,
+      :font4            => 14,
+      :font5            => 15,
+      :font6            => 16,
+      :font7            => 17,
+      :font8            => 18,
+      :font9            => 19,
+      :fraktur          => 20,
+      :bright_off       => 21,
+      :bold_off         => 21,
+      :double_underline => 21,
+      :clean            => 22,
+      :italic_off       => 23,
+      :fraktur_off      => 23,
+      :underline_off    => 24,
+      :blink_off        => 25,
+      :inverse_off      => 26,
+      :positive         => 26,
+      :conceal_off      => 27,
+      :show             => 27,
+      :reveal           => 27,
+      :crossed_off      => 29,
+      :crossed_out_off  => 29,
+
+      :black            => 30,
+      :red              => 31,
+      :green            => 32,
+      :yellow           => 33,
+      :blue             => 34,
+      :magenta          => 35,
+      :cyan             => 36,
+      :white            => 37,
+
+      :on_black         => 40,
+      :on_red           => 41,
+      :on_green         => 42,
+      :on_yellow        => 43,
+      :on_blue          => 44,
+      :on_magenta       => 45,
+      :on_cyan          => 46,
+      :on_white         => 47,
+
+      :frame            => 51,
+      :encircle         => 52,
+      :overline         => 53,
+      :frame_off        => 54,
+      :encircle_off     => 54,
+      :overline_off     => 55,
+    }
+
+  end
+
+end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,5 +1,6 @@
 require 'benchmark'
 require 'set'
+require 'dk/ansi'
 require 'dk/config'
 require 'dk/has_set_param'
 require 'dk/has_ssh_opts'
@@ -69,9 +70,17 @@ module Dk
       check_run_once_and_build_and_run_task(task_class, params)
     end
 
-    def log_info(msg);  self.logger.info("#{INDENT_LOG_PREFIX}#{msg}"); end
-    def log_debug(msg); self.logger.debug("#{INDENT_LOG_PREFIX}#{msg}"); end
-    def log_error(msg); self.logger.error("#{INDENT_LOG_PREFIX}#{msg}"); end
+    def log_info(msg, *ansi_styles)
+      self.logger.info("#{INDENT_LOG_PREFIX}#{Ansi.styled_msg(msg, *ansi_styles)}")
+    end
+
+    def log_debug(msg, *ansi_styles)
+      self.logger.debug("#{INDENT_LOG_PREFIX}#{Ansi.styled_msg(msg, *ansi_styles)}")
+    end
+
+    def log_error(msg, *ansi_styles)
+      self.logger.error("#{INDENT_LOG_PREFIX}#{Ansi.styled_msg(msg, *ansi_styles)}")
+    end
 
     def log_task_run(task_class, &run_block)
       self.logger.info ""

--- a/test/unit/ansi_tests.rb
+++ b/test/unit/ansi_tests.rb
@@ -1,0 +1,40 @@
+require 'assert'
+require 'dk/ansi'
+
+module Dk::Ansi
+
+  class UnitTests < Assert::Context
+    desc "Dk::Ansi"
+    subject{ Dk::Ansi }
+
+    should have_imeths :styled_msg, :code_for
+
+    should "know its codes" do
+      assert_not_empty subject::CODES
+    end
+
+    should "map its code style names to ansi code strings" do
+      styles = Factory.integer(3).times.map{ subject::CODES.keys.sample }
+      exp = styles.map{ |n| "\e[#{subject::CODES[n]}m" }.join('')
+      assert_equal exp, subject.code_for(*styles)
+
+      styles = Factory.integer(3).times.map{ Factory.string }
+      assert_equal '', subject.code_for(*styles)
+
+      styles = []
+      assert_equal '', subject.code_for(*styles)
+    end
+
+    should "know how to build ansi styled messages" do
+      msg = Factory.string
+      assert_equal msg, subject.styled_msg(msg)
+
+      styles   = Factory.integer(3).times.map{ subject::CODES.keys.sample }
+      exp_code = subject.code_for(*styles)
+      exp      = exp_code + msg + subject.code_for(:reset)
+      assert_equal exp, subject.styled_msg(msg, *styles)
+    end
+
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'dk/runner'
 
+require 'dk/ansi'
 require 'dk/config'
 require 'dk/has_set_param'
 require 'dk/has_ssh_opts'
@@ -173,18 +174,19 @@ class Dk::Runner
       logger_error_called_with = nil
       Assert.stub(@args[:logger], :error){ |*args| logger_error_called_with = args }
 
-      msg = Factory.string
+      msg    = Factory.string
+      styles = [[], [:bold, :red]].sample
 
-      subject.log_info msg
-      exp = ["#{INDENT_LOG_PREFIX}#{msg}"]
+      subject.log_info msg, *styles
+      exp = ["#{INDENT_LOG_PREFIX}#{Dk::Ansi.styled_msg(msg, *styles)}"]
       assert_equal exp, logger_info_called_with
 
-      subject.log_debug msg
-      exp = ["#{INDENT_LOG_PREFIX}#{msg}"]
+      subject.log_debug msg, *styles
+      exp = ["#{INDENT_LOG_PREFIX}#{Dk::Ansi.styled_msg(msg, *styles)}"]
       assert_equal exp, logger_debug_called_with
 
-      subject.log_error msg
-      exp = ["#{INDENT_LOG_PREFIX}#{msg}"]
+      subject.log_error msg, *styles
+      exp = ["#{INDENT_LOG_PREFIX}#{Dk::Ansi.styled_msg(msg, *styles)}"]
       assert_equal exp, logger_error_called_with
     end
 


### PR DESCRIPTION
This updates the `log_*` Task methods to task optional ansi style
symbol args.  If given, these styles will be applied to the msg
being logged.  These styles can also be applied manually (for
styling just a portion of a message) using `Dk::Ansi.styled_msg()`.

The goal is to give the user options for styling up their custom
log messages to help them stand out in logs.

@jcredding ready for review.
