### PR TITLE
Log a task only around its run, not around its callbacks

### DIFF
--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -68,8 +68,9 @@ module Dk
       end
 
       runner = get_runner(@config, @clirb.opts)
-      runner.log_cli_run(args.join(' '))
-      @clirb.args.each{ |task_name| runner.run(@config.task(task_name)) }
+      runner.log_cli_run(args.join(' ')) do
+        @clirb.args.each{ |task_name| runner.run(@config.task(task_name)) }
+      end
     end
 
     def help

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -89,10 +89,16 @@ module Dk
       self.logger.info "#{TASK_END_LOG_PREFIX}#{task_class} (#{self.pretty_run_time(time)})"
     end
 
-    def log_cli_run(cli_argv)
+    def log_cli_run(cli_argv, &run_block)
       15.times{ self.logger.debug "" }
       self.logger.debug "===================================="
       self.logger.debug ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `#{cli_argv}`"
+      self.logger.debug "===================================="
+      time = Benchmark.realtime(&run_block)
+      self.logger.info ""
+      self.logger.info "(#{self.pretty_run_time(time)})"
+      self.logger.debug "===================================="
+      self.logger.debug "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< `#{cli_argv}`"
       self.logger.debug "===================================="
     end
 

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -22,11 +22,11 @@ module Dk
       end
 
       def dk_run
+        self.dk_run_callbacks 'before'
         @dk_runner.log_task_run(self.class) do
-          self.dk_run_callbacks 'before'
           catch(:halt){ self.run! }
-          self.dk_run_callbacks 'after'
         end
+        self.dk_run_callbacks 'after'
       end
 
       def run!

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -59,7 +59,10 @@ class Dk::CLI
 
         runner = Assert.stub_send(Dk::DkRunner, :new, *args)
         Assert.stub(runner, :run){ |*args| @runner_runs << args }
-        Assert.stub(runner, :log_cli_run){ |*args| @log_cli_run_callbed_with = args }
+        Assert.stub(runner, :log_cli_run) do |*args, &block|
+          @log_cli_run_callbed_with = args
+          block.call
+        end
         runner
       end
       @cli_args = ['cli-test-task', 'cli-other-task']

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -209,18 +209,27 @@ class Dk::Runner
     end
 
     should "log the start of CLI runs" do
-      logger_debug_calls = []
-      Assert.stub(@args[:logger], :debug){ |*args| logger_debug_calls << args }
+      logger_calls = []
+      Assert.stub(@args[:logger], :debug){ |*args| logger_calls << [:debug, *args] }
+      Assert.stub(@args[:logger], :info){ |*args| logger_calls << [:info, *args] }
+
+      pretty_run_time = Factory.string
+      Assert.stub(subject, :pretty_run_time){ pretty_run_time }
 
       cli_argv = Factory.string
-      subject.log_cli_run(cli_argv)
+      subject.log_cli_run(cli_argv){}
 
-      exp = 15.times.map{ [""] } + [
-        ["===================================="],
-        [">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `#{cli_argv}`"],
-        ["===================================="]
+      exp = 15.times.map{ [:debug, ""] } + [
+        [:debug, "===================================="],
+        [:debug, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `#{cli_argv}`"],
+        [:debug, "===================================="],
+        [:info,  ""],
+        [:info,  "(#{pretty_run_time})"],
+        [:debug, "===================================="],
+        [:debug, "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< `#{cli_argv}`"],
+        [:debug, "===================================="]
       ]
-      assert_equal exp, logger_debug_calls
+      assert_equal exp, logger_calls
     end
 
     should "know if it has run a task or not" do


### PR DESCRIPTION
This changes the logging of a task to only be around its run and
not around its callbacks. This seperates the tasks in the logs and
makes them easier to read.

This moves the before and after callbacks out of the block that is
passed when logging the task run. This means the callbacks will be
logged separate from the original task.

This also updates the cli logging to add a footer and time the
entire running of the cli call. This partially replaces the
previous behavior in that it can give you timing information for
how long a task and all of its callbacks took to run. This also
is a new feature in the case multiple tasks are run since it shows
the total time it took to run all of the tasks. Finally, the footer
provides a nice bookend when looking at a log file. This makes it
even easier to see where one cli run ends and another begins.

Closes #58 

@kellyredding - Ready for review.
