### PR TITLE
pre-check all task names before running the tasks

### DIFF
--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -43,8 +43,8 @@ module Dk
       rescue CLIRB::VersionExit
         @kernel.puts Dk::VERSION
       rescue CLIRB::Error, Dk::Config::UnknownTaskError => exception
-        @kernel.puts "#{exception.message}\n\n"
         @kernel.puts help
+        @kernel.puts "\n\n#{exception.message}\n"
         @kernel.exit 1
       rescue StandardError => exception
         @kernel.puts "#{exception.class}: #{exception.message}"
@@ -61,6 +61,11 @@ module Dk
       raise ShowTaskList if @clirb.opts['list-tasks']
 
       @config.stdout_log_level('debug') if @clirb.opts['verbose']
+
+      unknowns = @clirb.args.select{ |name| !@config.tasks.keys.include?(name) }
+      if !unknowns.empty?
+        raise Dk::Config::UnknownTaskError, unknowns.map(&:inspect).join(', ')
+      end
 
       runner = get_runner(@config, @clirb.opts)
       runner.log_cli_run(args.join(' '))

--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -11,7 +11,7 @@ module Dk
 
     UnknownTaskError = Class.new(ArgumentError) do
       def initialize(task_name)
-        super("No task named #{task_name.inspect}")
+        super("No task named #{task_name}")
       end
     end
 
@@ -21,7 +21,7 @@ module Dk
     DEFAULT_SSH_HOSTS        = {}.freeze
     DEFAULT_SSH_ARGS         = ''.freeze
     DEFAULT_HOST_SSH_ARGS    = Hash.new{ |h, k| h[k] = DEFAULT_SSH_ARGS }
-    DEFAULT_TASKS            = Hash.new{ |h, k| raise UnknownTaskError.new(k) }.freeze
+    DEFAULT_TASKS            = Hash.new{ |h, k| raise UnknownTaskError.new(k.inspect) }.freeze
     DEFAULT_LOG_PATTERN      = "%m\n".freeze
     DEFAULT_LOG_FILE_PATTERN = '[%d %-5l] : %m\n'.freeze
     DEFAULT_STDOUT_LOG_LEVEL = 'info'.freeze

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -201,14 +201,14 @@ class Dk::CLI
   end
 
   class RunWithUnknownTaskTests < InitTests
-    desc "and run with an unknown task"
+    desc "and run with an unknown task(s)"
     setup do
-      @task_name = Factory.string
-      @cli.run(@task_name)
+      @task_names = Factory.integer(3).times.map{ Factory.string }
+      @cli.run(*@task_names)
     end
 
     should "output to the user that the task is not known and exit" do
-      exp = "No task named #{@task_name.inspect}"
+      exp = "No task named #{@task_names.map(&:inspect).join(', ')}"
       assert_includes exp, @kernel_spy.output
       assert_equal 1, @kernel_spy.exit_status
     end


### PR DESCRIPTION
The goal here is more friendly UX.  There is no need to start
running tasks if one of the named tasks the CLI is given is
unknown/invalid.  The switches to pre-checking the given task
names.

This pre-check raises the same UnknownTaskError the config does
on task lookup.  This means the same error handling will be used.
This does tweak that error handling to put the error messages
below the help output so the user will see them in their terminal.

```
$ dk whatever not-known
...

Options:
    -T, --[no-]list-tasks            list all tasks available to run
    -d, --[no-]dry-run               run the tasks without executing any local/remote cmds
    -t, --[no-]tree                  print out the tree of tasks/sub-tasks that would be run
    -v, --[no-]verbose               run tasks showing verbose (ie debug log level) details
        --version
        --help

No task named "whatever", "not-known"
$
```

@jcredding ready for review.
