### PR TITLE
update non-verbose logs to no longer show task starts/ends

### DIFF
--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -64,12 +64,16 @@ module Dk
 
       unknowns = @clirb.args.select{ |name| !@config.tasks.keys.include?(name) }
       if !unknowns.empty?
-        raise Dk::Config::UnknownTaskError, unknowns.map(&:inspect).join(', ')
+        raise Dk::Config::UnknownTaskError, unknowns.map{ |u| "`#{u}`"}.join(', ')
       end
 
       runner = get_runner(@config, @clirb.opts)
       runner.log_cli_run(args.join(' ')) do
-        @clirb.args.each{ |task_name| runner.run(@config.task(task_name)) }
+        @clirb.args.each do |task_name|
+          runner.log_cli_task_run(task_name) do
+            runner.run(@config.task(task_name))
+          end
+        end
       end
     end
 

--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -21,7 +21,7 @@ module Dk
     DEFAULT_SSH_HOSTS        = {}.freeze
     DEFAULT_SSH_ARGS         = ''.freeze
     DEFAULT_HOST_SSH_ARGS    = Hash.new{ |h, k| h[k] = DEFAULT_SSH_ARGS }
-    DEFAULT_TASKS            = Hash.new{ |h, k| raise UnknownTaskError.new(k.inspect) }.freeze
+    DEFAULT_TASKS            = Hash.new{ |h, k| raise UnknownTaskError.new("`#{k}`") }.freeze
     DEFAULT_LOG_PATTERN      = "%m\n".freeze
     DEFAULT_LOG_FILE_PATTERN = '[%d %-5l] : %m\n'.freeze
     DEFAULT_STDOUT_LOG_LEVEL = 'info'.freeze

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -83,10 +83,16 @@ module Dk
     end
 
     def log_task_run(task_class, &run_block)
-      self.logger.info ""
-      self.logger.info "#{TASK_START_LOG_PREFIX}#{task_class}"
+      self.logger.debug "#{TASK_START_LOG_PREFIX}#{task_class}"
       time = Benchmark.realtime(&run_block)
-      self.logger.info "#{TASK_END_LOG_PREFIX}#{task_class} (#{self.pretty_run_time(time)})"
+      self.logger.debug "#{TASK_END_LOG_PREFIX}#{task_class} (#{self.pretty_run_time(time)})"
+    end
+
+    def log_cli_task_run(task_name, &run_block)
+      self.logger.info "Starting `#{task_name}`."
+      time = Benchmark.realtime(&run_block)
+      self.logger.info "`#{task_name}` finished in #{self.pretty_run_time(time)}."
+      self.logger.info ""
       self.logger.info ""
     end
 
@@ -96,7 +102,6 @@ module Dk
       self.logger.debug ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `#{cli_argv}`"
       self.logger.debug "===================================="
       time = Benchmark.realtime(&run_block)
-      self.logger.info ""
       self.logger.info "(#{self.pretty_run_time(time)})"
       self.logger.debug "===================================="
       self.logger.debug "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< `#{cli_argv}`"

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -190,9 +190,9 @@ class Dk::Runner
       assert_equal exp, logger_error_called_with
     end
 
-    should "log the start/finish of task runs, including their run time" do
-      logger_info_calls = []
-      Assert.stub(@args[:logger], :info){ |*args| logger_info_calls << args }
+    should "debug log the start/finish of task runs, including their run time" do
+      logger_debug_calls = []
+      Assert.stub(@args[:logger], :debug){ |*args| logger_debug_calls << args }
 
       pretty_run_time = Factory.string
       Assert.stub(subject, :pretty_run_time){ pretty_run_time }
@@ -201,9 +201,26 @@ class Dk::Runner
       subject.log_task_run(task_class){}
 
       exp = [
-        [""],
         ["#{TASK_START_LOG_PREFIX}#{task_class}"],
         ["#{TASK_END_LOG_PREFIX}#{task_class} (#{pretty_run_time})"],
+      ]
+      assert_equal exp, logger_debug_calls
+    end
+
+    should "log the start/finish of CLI task runs, including their run time" do
+      logger_info_calls = []
+      Assert.stub(@args[:logger], :info){ |*args| logger_info_calls << args }
+
+      pretty_run_time = Factory.string
+      Assert.stub(subject, :pretty_run_time){ pretty_run_time }
+
+      task_name = Factory.string
+      subject.log_cli_task_run(task_name){}
+
+      exp = [
+        ["Starting `#{task_name}`."],
+        ["`#{task_name}` finished in #{pretty_run_time}."],
+        [""],
         [""]
       ]
       assert_equal exp, logger_info_calls
@@ -224,7 +241,6 @@ class Dk::Runner
         [:debug, "===================================="],
         [:debug, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `#{cli_argv}`"],
         [:debug, "===================================="],
-        [:info,  ""],
         [:info,  "(#{pretty_run_time})"],
         [:debug, "===================================="],
         [:debug, "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< `#{cli_argv}`"],


### PR DESCRIPTION
This is a UX effort to keep the default log output as clean and
readable as possible.  This removes the "chunked" newlines before
and after task start/end and switches individual task run start
and end logs to be at the debug level.  This gets them off by
default.  Then, so that we don't have rando cmds/logs with no
context, this updates each top level cli task run to log at the
info level its start end.

I like this better b/c it is more clean and highlights the cmds
being run and any custom log more than what tasks are being run.
The start/stop logs that are displayed correspond to the user
input which makes it intuitive.

```
$ dk my-task my-other-task
Starting `my-task`.
      running the sub task
      running what the sub task does
[CMD] <some cmd str>
      (200.0ms)
      > cmd output line 1
      > cmd output line 2
[SSH] <some cmd str>
      ssh -o ...  <host> -- "sh -c \"<some cmd str>\""
      [host1]
      [host2]
      (913.5ms)
`my-task` finished in 0:01s.


Starting `my-other-task`
      doing what the other task does
`my-other-task` finished in 347.3ms.


(0:01s)
$
```

Note: this also tweaks any reference to a task name to wrap it
in backticks - this looks "more official" than double-quotes.

@jcredding ready for review.  Whaddaya think of this?
