### PR TITLE
tweak the task run start/end log buffer identifiers

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -14,8 +14,8 @@ module Dk
     include Dk::HasSetParam
     include Dk::HasSSHOpts
 
-    TASK_START_LOG_PREFIX  = '***** '.freeze
-    TASK_END_LOG_PREFIX    = '..... '.freeze
+    TASK_START_LOG_PREFIX  = ' >>>  '.freeze
+    TASK_END_LOG_PREFIX    = ' <<<  '.freeze
     INDENT_LOG_PREFIX      = '      '.freeze
     CMD_LOG_PREFIX         = '[CMD] '.freeze
     SSH_LOG_PREFIX         = '[SSH] '.freeze

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -28,8 +28,8 @@ class Dk::Runner
     end
 
     should "know its log prefix values" do
-      assert_equal '***** ', subject::TASK_START_LOG_PREFIX
-      assert_equal '..... ', subject::TASK_END_LOG_PREFIX
+      assert_equal ' >>>  ', subject::TASK_START_LOG_PREFIX
+      assert_equal ' <<<  ', subject::TASK_END_LOG_PREFIX
       assert_equal '      ', subject::INDENT_LOG_PREFIX
       assert_equal '[CMD] ', subject::CMD_LOG_PREFIX
       assert_equal '[SSH] ', subject::SSH_LOG_PREFIX


### PR DESCRIPTION
This is an attempt to make the logs more readable now that these
entries are no longer "chunked" with new lines and only appear in
verbose logging scenarios.  I like the forward/backward arrows as
they map to starting/ending things.

Note: I chose to make these 3 chars long to center them on the cmd
and ssh buffer identifiers.

```
> bundle exec dk my-task --dry-run --verbose













====================================
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> `my-task --dry-run --verbose`
====================================
Starting `my-task`
 >>>  SubSubTask
 <<<  SubSubTask (1.0ms)
 >>>  SubTask
 <<<  SubTask (1.0ms)
 >>>  MyTask
[CMD] ls -la .
[SSH] echo 'whatever'
      [host1]
      [host2]
      (352.7ms)
 <<<  MyTask (354.5ms)
`my-task` finished in 356.7ms.

(356.9ms)
====================================
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< `my-task --dry-run --verbose`
====================================
```

@jcredding you cool with this change?
