### PR TITLE
update stubs API to optionally take proc values

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,14 +605,31 @@ test "my task should do something" do
   runner.stub_cmd("ls -la") do |spy| # spy is a Local::CmdSpy
     spy.stdout = "..."
   end
-  runner.stub_ssh("ls -la") do |spy| # spy is a Remote::CmdSpy
+  runner.stub_ssh("ls -la", :input => 'whatever') do |spy| # spy is a Remote::CmdSpy
     spy.exitstatus = 1 # simulare the ssh call failing
   end
 
-  runner.run
+  # ....
+end
+```
 
-  # make assertions about how your task used the stdout of the
-  # cmd and handled the ssh call that failed
+You can even stub with procs.  Those procs will be instance eval'd against the task to determine if the stub is a match.  This allows you to stub the same way the call is made in the task (which is handy when the cmds are driven by dynamic values on the task instance).
+
+```ruby
+# in your test file or whatever
+
+include Dk::Task::TestHelpers
+
+test "my task should do something" do
+  runner = test_runner(MyTask)
+  runner.stub_cmd(proc{ self.class.some_cmd_str }, :opts => proc{ some_opts }) do |spy| # spy is a Local::CmdSpy
+    spy.stdout = "..."
+  end
+  runner.stub_ssh("ls -la", :input => proc{ some_task_input_val }) do |spy| # spy is a Remote::CmdSpy
+    spy.exitstatus = 1 # simulare the ssh call failing
+  end
+
+  # ....
 end
 ```
 

--- a/lib/dk/config.rb
+++ b/lib/dk/config.rb
@@ -134,16 +134,28 @@ module Dk
       @log_file_pattern
     end
 
-    def stub_dry_tree_cmd(cmd_str, *args, &block)
-      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-      input      = args.last
-      @dry_tree_cmd_stubs << DryTreeStub.new(cmd_str, input, given_opts, block)
+    def stub_dry_tree_cmd(cmd_str, args = nil, &block)
+      args ||= {}
+
+      cmd_str_proc    = get_cmd_ssh_proc(cmd_str)
+      input_proc      = get_cmd_ssh_proc(args[:input])
+      given_opts_proc = get_cmd_ssh_proc(args[:opts])
+
+      @dry_tree_cmd_stubs.unshift(
+        DryTreeStub.new(cmd_str_proc, input_proc, given_opts_proc, block)
+      )
     end
 
-    def stub_dry_tree_ssh(cmd_str, *args, &block)
-      given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-      input      = args.last
-      @dry_tree_ssh_stubs << DryTreeStub.new(cmd_str, input, given_opts, block)
+    def stub_dry_tree_ssh(cmd_str, args = nil, &block)
+      args ||= {}
+
+      cmd_str_proc    = get_cmd_ssh_proc(cmd_str)
+      input_proc      = get_cmd_ssh_proc(args[:input])
+      given_opts_proc = get_cmd_ssh_proc(args[:opts])
+
+      @dry_tree_ssh_stubs.unshift(
+        DryTreeStub.new(cmd_str_proc, input_proc, given_opts_proc, block)
+      )
     end
 
     # private - intended for internal use only
@@ -161,6 +173,14 @@ module Dk
     def dk_logger
       @dk_logger ||= LogslyLogger.new(self)
     end
+
+    private
+
+    def get_cmd_ssh_proc(obj)
+      obj.kind_of?(::Proc) ? obj : proc{ obj }
+    end
+
+    DryTreeStub = Struct.new(:cmd_str_proc, :input_proc, :given_opts_proc, :block)
 
     class LogslyLogger
       include Logsly
@@ -191,8 +211,6 @@ module Dk
       end
 
     end
-
-    DryTreeStub = Struct.new(:cmd_str, :input, :given_opts, :block)
 
   end
 

--- a/lib/dk/dry_runner.rb
+++ b/lib/dk/dry_runner.rb
@@ -11,10 +11,16 @@ module Dk
     def initialize(config, *args)
       super(config, *args)
       config.dry_tree_cmd_stubs.each do |s|
-        self.stub_cmd(s.cmd_str, s.input, s.given_opts, &s.block)
+        self.stub_cmd(s.cmd_str_proc, {
+          :input => s.input_proc,
+          :opts  => s.given_opts_proc
+        }, &s.block)
       end
       config.dry_tree_ssh_stubs.each do |s|
-        self.stub_ssh(s.cmd_str, s.input, s.given_opts, &s.block)
+        self.stub_ssh(s.cmd_str_proc, {
+          :input => s.input_proc,
+          :opts  => s.given_opts_proc
+        }, &s.block)
       end
     end
 

--- a/lib/dk/has_the_stubs.rb
+++ b/lib/dk/has_the_stubs.rb
@@ -16,69 +16,70 @@ module Dk
 
       # cmd stub api
 
-      def stub_cmd(cmd_str, *args, &block)
-        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-        input      = args.last
-
-        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
-        local_cmd_stub_blocks[key] = block
+      def local_cmd_stubs
+        @local_cmd_stubs ||= []
       end
 
-      def unstub_cmd(cmd_str, *args)
-        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-        input      = args.last
+      def stub_cmd(cmd_str, args = nil, &block)
+        args ||= {}
 
-        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
-        local_cmd_stub_blocks.delete(key)
-        local_cmd_spies.delete(key)
+        cmd_str_proc    = get_cmd_ssh_proc(cmd_str)
+        input_proc      = get_cmd_ssh_proc(args[:input])
+        given_opts_proc = get_cmd_ssh_proc(args[:opts])
+
+        local_cmd_stubs.unshift(
+          Stub.new(cmd_str_proc, input_proc, given_opts_proc, block)
+        )
       end
 
       def unstub_all_cmds
-        local_cmd_stub_blocks.clear
-        local_cmd_spies.clear
-      end
-
-      def local_cmd_stubs
-        local_cmd_stub_blocks.map{ |key, block| Stub.new(*(key + [block])) }
+        local_cmd_stubs.clear
       end
 
       # ssh stub API
 
-      def stub_ssh(cmd_str, *args, &block)
-        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-        input      = args.last
-
-        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
-        remote_cmd_stub_blocks[key] = block
+      def remote_cmd_stubs
+        @remote_cmd_stubs ||= []
       end
 
-      def unstub_ssh(cmd_str, *args)
-        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
-        input      = args.last
+      def stub_ssh(cmd_str, args = nil, &block)
+        args ||= {}
 
-        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
-        remote_cmd_stub_blocks.delete(key)
-        remote_cmd_spies.delete(key)
+        cmd_str_proc    = get_cmd_ssh_proc(cmd_str)
+        input_proc      = get_cmd_ssh_proc(args[:input])
+        given_opts_proc = get_cmd_ssh_proc(args[:opts])
+
+        remote_cmd_stubs.unshift(
+          Stub.new(cmd_str_proc, input_proc, given_opts_proc, block)
+        )
       end
 
       def unstub_all_ssh
-        remote_cmd_stub_blocks.clear
-        remote_cmd_spies.clear
-      end
-
-      def remote_cmd_stubs
-        remote_cmd_stub_blocks.map{ |key, block| Stub.new(*(key + [block])) }
+        remote_cmd_stubs.clear
       end
 
       private
 
+      def get_cmd_ssh_proc(obj)
+        obj.kind_of?(::Proc) ? obj : proc{ obj }
+      end
+
+      def find_cmd_ssh_stub_block(stubs, task, cmd_str, input, given_opts)
+        stub = stubs.find do |stub|
+          task.instance_eval(&stub.cmd_str_proc)    == cmd_str    &&
+          task.instance_eval(&stub.input_proc)      == input      &&
+          task.instance_eval(&stub.given_opts_proc) == given_opts
+        end
+        stub ? stub.block : nil
+      end
+
       # if the cmd is stubbed, build a spy and apply the stub (or return the
       # cached spy), otherwise let the runner decide how to handle the local
       # cmd
-      def build_local_cmd(cmd_str, input, given_opts)
-        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
-        if (block = local_cmd_stub_blocks[key])
-          local_cmd_spies[key] ||= Local::CmdSpy.new(cmd_str, given_opts).tap(&block)
+      def build_local_cmd(task, cmd_str, input, given_opts)
+        b = find_cmd_ssh_stub_block(local_cmd_stubs, task, cmd_str, input, given_opts)
+        if b
+          Local::CmdSpy.new(cmd_str, given_opts).tap(&b)
         else
           has_the_stubs_build_local_cmd(cmd_str, given_opts)
         end
@@ -88,18 +89,15 @@ module Dk
         raise NotImplementedError
       end
 
-      def local_cmd_stub_blocks; @local_cmd_stub_blocks ||= {}; end
-      def local_cmd_spies;       @local_cmd_spies       ||= {}; end
-
       # if the cmd is stubbed, build a spy and apply the stub (or return the
       # cached spy), otherwise let the runner decide how to handle the remote
       # cmd; when building the spy use the ssh opts, this allows stubbing and
       # calling ssh cmds with the same opts but also allows building a valid
       # remote cmd that has an ssh host
-      def build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
-        key = has_the_stubs_cmd_key(cmd_str, input, given_opts)
-        if (block = remote_cmd_stub_blocks[key])
-          remote_cmd_spies[key] ||= Remote::CmdSpy.new(cmd_str, ssh_opts).tap(&block)
+      def build_remote_cmd(task, cmd_str, input, given_opts, ssh_opts)
+        b = find_cmd_ssh_stub_block(remote_cmd_stubs, task, cmd_str, input, given_opts)
+        if b
+          Remote::CmdSpy.new(cmd_str, ssh_opts).tap(&b)
         else
           has_the_stubs_build_remote_cmd(cmd_str, ssh_opts)
         end
@@ -109,16 +107,9 @@ module Dk
         raise NotImplementedError
       end
 
-      def remote_cmd_stub_blocks; @remote_cmd_stub_blocks ||= {}; end
-      def remote_cmd_spies;       @remote_cmd_spies       ||= {}; end
-
-      def has_the_stubs_cmd_key(cmd_str, input, given_opts)
-        [cmd_str, input, given_opts]
-      end
-
     end
 
-    Stub = Struct.new(:cmd_str, :input, :given_opts, :block)
+    Stub = Struct.new(:cmd_str_proc, :input_proc, :given_opts_proc, :block)
 
   end
 

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -108,12 +108,12 @@ module Dk
       self.logger.debug "===================================="
     end
 
-    def cmd(cmd_str, input, given_opts)
-      build_and_run_local_cmd(cmd_str, input, given_opts)
+    def cmd(task, cmd_str, input, given_opts)
+      build_and_run_local_cmd(task, cmd_str, input, given_opts)
     end
 
-    def ssh(cmd_str, input, given_opts, ssh_opts)
-      build_and_run_remote_cmd(cmd_str, input, given_opts, ssh_opts)
+    def ssh(task, cmd_str, input, given_opts, ssh_opts)
+      build_and_run_remote_cmd(task, cmd_str, input, given_opts, ssh_opts)
     end
 
     def has_run_task?(task_class)
@@ -149,14 +149,14 @@ module Dk
       task_class.new(self, params)
     end
 
-    def build_and_run_local_cmd(cmd_str, input, given_opts)
-      local_cmd = build_local_cmd(cmd_str, input, given_opts)
+    def build_and_run_local_cmd(task, cmd_str, input, given_opts)
+      local_cmd = build_local_cmd(task, cmd_str, input, given_opts)
       log_local_cmd(local_cmd){ |cmd| cmd.run(input) }
     end
 
     # input is needed for the `TestRunner` so it can use it with stubbing
     # otherwise it is ignored when building a local cmd
-    def build_local_cmd(cmd_str, input, given_opts)
+    def build_local_cmd(task, cmd_str, input, given_opts)
       Local::Cmd.new(cmd_str, given_opts)
     end
 
@@ -169,14 +169,14 @@ module Dk
       cmd
     end
 
-    def build_and_run_remote_cmd(cmd_str, input, given_opts, ssh_opts)
-      remote_cmd = build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
+    def build_and_run_remote_cmd(task, cmd_str, input, given_opts, ssh_opts)
+      remote_cmd = build_remote_cmd(task, cmd_str, input, given_opts, ssh_opts)
       log_remote_cmd(remote_cmd){ |cmd| cmd.run(input) }
     end
 
     # input and given opts are needed for the `TestRunner` so it can use it with
     # stubbing otherwise they are ignored when building a remote cmd
-    def build_remote_cmd(cmd_str, input, given_opts, ssh_opts)
+    def build_remote_cmd(task, cmd_str, input, given_opts, ssh_opts)
       Remote::Cmd.new(cmd_str, ssh_opts)
     end
 

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -60,7 +60,7 @@ module Dk
       def cmd(cmd_str, *args)
         given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
         input      = args.last
-        @dk_runner.cmd(cmd_str, input, given_opts)
+        @dk_runner.cmd(self, cmd_str, input, given_opts)
       end
 
       def cmd!(cmd_str, *args)
@@ -74,7 +74,7 @@ module Dk
       def ssh(cmd_str, *args)
         given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
         input      = args.last
-        @dk_runner.ssh(cmd_str, input, given_opts, dk_build_ssh_opts(given_opts))
+        @dk_runner.ssh(self, cmd_str, input, given_opts, dk_build_ssh_opts(given_opts))
       end
 
       def ssh!(cmd_str, *args)

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -24,13 +24,13 @@ module Dk
     end
 
     # track that a local cmd was run
-    def cmd(cmd_str, input, given_opts)
-      super(cmd_str, input, given_opts).tap{ |c| self.runs << c }
+    def cmd(task, cmd_str, input, given_opts)
+      super(task, cmd_str, input, given_opts).tap{ |c| self.runs << c }
     end
 
     # track that a remote cmd was run
-    def ssh(cmd_str, input, given_opts, ssh_opts)
-      super(cmd_str, input, given_opts, ssh_opts).tap{ |c| self.runs << c }
+    def ssh(task, cmd_str, input, given_opts, ssh_opts)
+      super(task, cmd_str, input, given_opts, ssh_opts).tap{ |c| self.runs << c }
     end
 
     # test task API

--- a/test/system/runner_tests.rb
+++ b/test/system/runner_tests.rb
@@ -81,12 +81,21 @@ class Dk::Runner
     setup do
       @runner = Dk::DryRunner.new(@dk_config)
 
+      stub_cmd_str = [
+        @params['stubbed_cmd_str'],
+        proc{ params['stubbed_cmd_str']}
+      ].sample
+
       # stub a cmd/ssh using `dry_tree_run` so we can test that the stub takes
       # precedence over the `dry_tree_run` opt
-      @runner.stub_cmd(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+      @runner.stub_cmd(stub_cmd_str, {
+        :opts => { :dry_tree_run => true }
+      }) do |s|
         s.stdout = Factory.string
       end
-      @runner.stub_ssh(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+      @runner.stub_ssh(stub_cmd_str, {
+        :opts => { :dry_tree_run => true }
+      }) do |s|
         s.stdout = Factory.string
       end
 
@@ -125,12 +134,21 @@ class Dk::Runner
     setup do
       @runner = Dk::TreeRunner.new(@dk_config, StringIO.new)
 
+      stub_cmd_str = [
+        @params['stubbed_cmd_str'],
+        proc{ params['stubbed_cmd_str']}
+      ].sample
+
       # stub a cmd/ssh using `dry_tree_run` so we can test that the stub takes
       # precedence over the `dry_tree_run` opt
-      @runner.stub_cmd(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+      @runner.stub_cmd(stub_cmd_str, {
+        :opts => { :dry_tree_run => true }
+      }) do |s|
         s.stdout = Factory.string
       end
-      @runner.stub_ssh(@params['stubbed_cmd_str'], :dry_tree_run => true) do |s|
+      @runner.stub_ssh(stub_cmd_str, {
+        :opts => { :dry_tree_run => true }
+      }) do |s|
         s.stdout = Factory.string
       end
 

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -240,64 +240,6 @@ class Dk::Config
       assert_equal pattern, subject.log_file_pattern
     end
 
-    should "allow adding dry tree runner cmd stubs" do
-      cmd_str    = Factory.string
-      cmd_input  = Factory.string
-      cmd_opts   = { Factory.string => Factory.string }
-      stub_block = Proc.new{ Factory.string }
-
-      assert_equal 0, subject.dry_tree_cmd_stubs.size
-
-      subject.stub_dry_tree_cmd(cmd_str, &stub_block)
-      assert_equal 1, subject.dry_tree_cmd_stubs.size
-      exp = DryTreeStub.new(cmd_str, nil, nil, stub_block)
-      assert_includes exp, subject.dry_tree_cmd_stubs
-
-      subject.stub_dry_tree_cmd(cmd_str, cmd_input, &stub_block)
-      assert_equal 2, subject.dry_tree_cmd_stubs.size
-      exp = DryTreeStub.new(cmd_str, cmd_input, nil, stub_block)
-      assert_includes exp, subject.dry_tree_cmd_stubs
-
-      subject.stub_dry_tree_cmd(cmd_str, cmd_opts, &stub_block)
-      assert_equal 3, subject.dry_tree_cmd_stubs.size
-      exp = DryTreeStub.new(cmd_str, nil, cmd_opts, stub_block)
-      assert_includes exp, subject.dry_tree_cmd_stubs
-
-      subject.stub_dry_tree_cmd(cmd_str, cmd_input, cmd_opts, &stub_block)
-      assert_equal 4, subject.dry_tree_cmd_stubs.size
-      exp = DryTreeStub.new(cmd_str, cmd_input, cmd_opts, stub_block)
-      assert_includes exp, subject.dry_tree_cmd_stubs
-    end
-
-    should "allow adding dry tree runner ssh stubs" do
-      cmd_str    = Factory.string
-      cmd_input  = Factory.string
-      ssh_opts   = Factory.ssh_cmd_opts
-      stub_block = Proc.new{ Factory.string }
-
-      assert_equal 0, subject.dry_tree_ssh_stubs.size
-
-      subject.stub_dry_tree_ssh(cmd_str, &stub_block)
-      assert_equal 1, subject.dry_tree_ssh_stubs.size
-      exp = DryTreeStub.new(cmd_str, nil, nil, stub_block)
-      assert_includes exp, subject.dry_tree_ssh_stubs
-
-      subject.stub_dry_tree_ssh(cmd_str, cmd_input, &stub_block)
-      assert_equal 2, subject.dry_tree_ssh_stubs.size
-      exp = DryTreeStub.new(cmd_str, cmd_input, nil, stub_block)
-      assert_includes exp, subject.dry_tree_ssh_stubs
-
-      subject.stub_dry_tree_ssh(cmd_str, ssh_opts, &stub_block)
-      assert_equal 3, subject.dry_tree_ssh_stubs.size
-      exp = DryTreeStub.new(cmd_str, nil, ssh_opts, stub_block)
-      assert_includes exp, subject.dry_tree_ssh_stubs
-
-      subject.stub_dry_tree_ssh(cmd_str, cmd_input, ssh_opts, &stub_block)
-      assert_equal 4, subject.dry_tree_ssh_stubs.size
-      exp = DryTreeStub.new(cmd_str, cmd_input, ssh_opts, stub_block)
-      assert_includes exp, subject.dry_tree_ssh_stubs
-    end
-
     should "know its logger output names" do
       exp = "dk-config-#{subject.object_id}-stdout"
       assert_equal exp, subject.dk_logger_stdout_output_name
@@ -311,6 +253,106 @@ class Dk::Config
 
       assert_instance_of LogslyLogger, logger
       assert_equal subject, logger.config
+    end
+
+  end
+
+  class DryTreeStubsTests < InitTests
+    setup do
+      raw_cmd_str    = Factory.string
+      raw_input      = Factory.string
+      raw_given_opts = { Factory.string => Factory.string }
+
+      @cmd_str    = [@raw_cmd_str, proc{ "#{raw_cmd_str},#{some_attr}" }].sample
+      @input      = [@raw_input,   proc{ "#{raw_input},#{some_attr}" }].sample
+      @given_opts = [
+        @raw_given_opts,
+        proc{ raw_given_opts.merge('some_attr' => some_attr) }
+      ].sample
+      @ssh_opts   = { :hosts => Factory.hosts }
+      @stub_block = Proc.new{ |s| Factory.string }
+
+      task_class = Class.new{ def some_attr; @some_attr ||= Factory.string; end }
+      @task      = task_class.new
+    end
+
+    should "allow adding dry tree runner cmd stubs" do
+      assert_equal 0, subject.dry_tree_cmd_stubs.size
+
+      cmd_str    = get_raw_value(@cmd_str)
+      input      = get_raw_value(@input)
+      given_opts = get_raw_value(@given_opts)
+
+      subject.stub_dry_tree_cmd(@cmd_str, &@stub_block)
+      assert_equal 1, subject.dry_tree_cmd_stubs.size
+      assert_equal @stub_block, lookup_cmd_stub_block(cmd_str, nil, nil)
+
+      subject.stub_dry_tree_cmd(@cmd_str, :input => @input, &@stub_block)
+      assert_equal 2, subject.dry_tree_cmd_stubs.size
+      assert_equal @stub_block, lookup_cmd_stub_block(cmd_str, input, nil)
+
+      subject.stub_dry_tree_cmd(@cmd_str, :opts => @given_opts, &@stub_block)
+      assert_equal 3, subject.dry_tree_cmd_stubs.size
+      assert_equal @stub_block, lookup_cmd_stub_block(cmd_str, nil, given_opts)
+
+      subject.stub_dry_tree_cmd(@cmd_str, {
+        :input => @input,
+        :opts  => @given_opts
+      }, &@stub_block)
+      assert_equal 4, subject.dry_tree_cmd_stubs.size
+      assert_equal @stub_block, lookup_cmd_stub_block(cmd_str, input, given_opts)
+    end
+
+    should "allow adding dry tree runner ssh stubs" do
+      assert_equal 0, subject.dry_tree_ssh_stubs.size
+
+      cmd_str    = get_raw_value(@cmd_str)
+      input      = get_raw_value(@input)
+      given_opts = get_raw_value(@given_opts)
+
+      subject.stub_dry_tree_ssh(@cmd_str, &@stub_block)
+      assert_equal 1, subject.dry_tree_ssh_stubs.size
+      assert_equal @stub_block, lookup_ssh_stub_block(cmd_str, nil, nil)
+
+      subject.stub_dry_tree_ssh(@cmd_str, :input => @input, &@stub_block)
+      assert_equal 2, subject.dry_tree_ssh_stubs.size
+      assert_equal @stub_block, lookup_ssh_stub_block(cmd_str, input, nil)
+
+      subject.stub_dry_tree_ssh(@cmd_str, :opts => @given_opts, &@stub_block)
+      assert_equal 3, subject.dry_tree_ssh_stubs.size
+      assert_equal @stub_block, lookup_ssh_stub_block(cmd_str, nil, given_opts)
+
+      subject.stub_dry_tree_ssh(@cmd_str, {
+        :input => @input,
+        :opts  => @given_opts
+      }, &@stub_block)
+      assert_equal 4, subject.dry_tree_ssh_stubs.size
+      assert_equal @stub_block, lookup_ssh_stub_block(cmd_str, input, given_opts)
+    end
+
+    private
+
+    def get_raw_value(value)
+      value.kind_of?(::Proc) ? @task.instance_eval(&value) : value
+    end
+
+    def lookup_cmd_stub_block(cmd_str, input, given_opts)
+      stubs = @config.dry_tree_cmd_stubs
+      find_cmd_ssh_stub_block(stubs, @task, cmd_str, input, given_opts)
+    end
+
+    def lookup_ssh_stub_block(cmd_str, input, given_opts)
+      stubs = @config.dry_tree_ssh_stubs
+      find_cmd_ssh_stub_block(stubs, @task, cmd_str, input, given_opts)
+    end
+
+    def find_cmd_ssh_stub_block(stubs, task, cmd_str, input, given_opts)
+      stub = stubs.find do |stub|
+        task.instance_eval(&stub.cmd_str_proc)    == cmd_str    &&
+        task.instance_eval(&stub.input_proc)      == input      &&
+        task.instance_eval(&stub.given_opts_proc) == given_opts
+      end
+      stub ? stub.block : nil
     end
 
   end

--- a/test/unit/dry_runner_tests.rb
+++ b/test/unit/dry_runner_tests.rb
@@ -29,13 +29,15 @@ class Dk::DryRunner
     setup do
       @dk_config = Dk::Config.new
       Factory.integer(3).times.each do
-        @dk_config.stub_dry_tree_cmd(Factory.string, Factory.string, {
-          Factory.string => Factory.string
+        @dk_config.stub_dry_tree_cmd(Factory.string, {
+          :input => Factory.string,
+          :opts  => { Factory.string => Factory.string }
         }){ |s| Factory.string }
       end
       Factory.integer(3).times.each do
-        @dk_config.stub_dry_tree_ssh(Factory.string, Factory.string, {
-          Factory.string => Factory.string
+        @dk_config.stub_dry_tree_ssh(Factory.string, {
+          :input => Factory.string,
+          :opts  => { Factory.string => Factory.string }
         }){ |s| Factory.string }
       end
 
@@ -46,18 +48,18 @@ class Dk::DryRunner
     should "add cmd/ssh dry tree stubs from its config" do
       @dk_config.dry_tree_cmd_stubs.each do |stub|
         exp = Dk::HasTheStubs::Stub.new(
-          stub.cmd_str,
-          stub.input,
-          stub.given_opts,
+          stub.cmd_str_proc,
+          stub.input_proc,
+          stub.given_opts_proc,
           stub.block
         )
         assert_includes exp, @runner.local_cmd_stubs
       end
       @dk_config.dry_tree_ssh_stubs.each do |stub|
         exp = Dk::HasTheStubs::Stub.new(
-          stub.cmd_str,
-          stub.input,
-          stub.given_opts,
+          stub.cmd_str_proc,
+          stub.input_proc,
+          stub.given_opts_proc,
           stub.block
         )
         assert_includes exp, @runner.remote_cmd_stubs

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -301,11 +301,12 @@ class Dk::Runner
         end
       end
 
+      @task   = Factory.string
       @runner = @runner_class.new(@runner_opts)
     end
 
     should "build, log and run local cmds" do
-      @runner.cmd(@cmd_str, @cmd_input, @cmd_given_opts)
+      @runner.cmd(@task, @cmd_str, @cmd_input, @cmd_given_opts)
 
       exp = [@cmd_str, @cmd_given_opts]
       assert_equal exp, @local_cmd_new_called_with
@@ -343,6 +344,7 @@ class Dk::Runner
         end
       end
 
+      @task   = Factory.string
       @runner = @runner_class.new(@runner_opts)
 
       @pretty_run_time = Factory.string
@@ -350,7 +352,7 @@ class Dk::Runner
     end
 
     should "build, log and run remote cmds" do
-      @runner.ssh(@cmd_str, @cmd_input, @cmd_given_opts, @cmd_ssh_opts)
+      @runner.ssh(@task, @cmd_str, @cmd_input, @cmd_given_opts, @cmd_ssh_opts)
 
       exp = [@cmd_str, @cmd_ssh_opts]
       assert_equal exp, @remote_cmd_new_called_with

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -303,35 +303,35 @@ module Dk::Task
       cmd_opts  = { Factory.string => Factory.string }
 
       subject.instance_eval{ cmd(cmd_str, cmd_input, cmd_opts) }
-      exp = [cmd_str, cmd_input, cmd_opts]
+      exp = [subject, cmd_str, cmd_input, cmd_opts]
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd(cmd_str) }
-      exp = [cmd_str, nil, nil]
+      exp = [subject, cmd_str, nil, nil]
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd(cmd_str, cmd_input) }
-      exp = [cmd_str, cmd_input, nil]
+      exp = [subject, cmd_str, cmd_input, nil]
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd(cmd_str, cmd_opts) }
-      exp = [cmd_str, nil, cmd_opts]
+      exp = [subject, cmd_str, nil, cmd_opts]
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd!(cmd_str, cmd_input, cmd_opts) }
-      exp = [cmd_str, cmd_input, cmd_opts]
+      exp = [subject, cmd_str, cmd_input, cmd_opts]
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd!(cmd_str) }
-      exp = [cmd_str, nil, nil]
+      exp = [subject, cmd_str, nil, nil]
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd!(cmd_str, cmd_input) }
-      exp = [cmd_str, cmd_input, nil]
+      exp = [subject, cmd_str, cmd_input, nil]
       assert_equal exp, runner_cmd_called_with
 
       subject.instance_eval{ cmd!(cmd_str, cmd_opts) }
-      exp = [cmd_str, nil, cmd_opts]
+      exp = [subject, cmd_str, nil, cmd_opts]
       assert_equal exp, runner_cmd_called_with
     end
 
@@ -355,7 +355,7 @@ module Dk::Task
       exp = "error running `#{cmd_str}`"
       assert_equal exp, err.message
 
-      exp = [cmd_str, cmd_input, cmd_opts]
+      exp = [subject, cmd_str, cmd_input, cmd_opts]
       assert_equal exp, runner_cmd_called_with
     end
 
@@ -377,35 +377,35 @@ module Dk::Task
       exp_cmd_ssh_opts = @default_ssh_cmd_opts.merge(cmd_given_opts)
 
       subject.instance_eval{ ssh(cmd_str, cmd_input, cmd_given_opts) }
-      exp = [cmd_str, cmd_input, cmd_given_opts, exp_cmd_ssh_opts]
+      exp = [subject, cmd_str, cmd_input, cmd_given_opts, exp_cmd_ssh_opts]
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh(cmd_str) }
-      exp = [cmd_str, nil, nil, @default_ssh_cmd_opts]
+      exp = [subject, cmd_str, nil, nil, @default_ssh_cmd_opts]
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh(cmd_str, cmd_input) }
-      exp = [cmd_str, cmd_input, nil, @default_ssh_cmd_opts]
+      exp = [subject, cmd_str, cmd_input, nil, @default_ssh_cmd_opts]
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh(cmd_str, cmd_given_opts) }
-      exp = [cmd_str, nil, cmd_given_opts, exp_cmd_ssh_opts]
+      exp = [subject, cmd_str, nil, cmd_given_opts, exp_cmd_ssh_opts]
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh!(cmd_str, cmd_input, cmd_given_opts) }
-      exp = [cmd_str, cmd_input, cmd_given_opts, exp_cmd_ssh_opts]
+      exp = [subject, cmd_str, cmd_input, cmd_given_opts, exp_cmd_ssh_opts]
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh!(cmd_str) }
-      exp = [cmd_str, nil, nil, @default_ssh_cmd_opts]
+      exp = [subject, cmd_str, nil, nil, @default_ssh_cmd_opts]
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh!(cmd_str, cmd_input) }
-      exp = [cmd_str, cmd_input, nil, @default_ssh_cmd_opts]
+      exp = [subject, cmd_str, cmd_input, nil, @default_ssh_cmd_opts]
       assert_equal exp, runner_ssh_called_with
 
       subject.instance_eval{ ssh!(cmd_str, cmd_given_opts) }
-      exp = [cmd_str, nil, cmd_given_opts, exp_cmd_ssh_opts]
+      exp = [subject, cmd_str, nil, cmd_given_opts, exp_cmd_ssh_opts]
       assert_equal exp, runner_ssh_called_with
     end
 
@@ -427,7 +427,7 @@ module Dk::Task
 
     should "force any given hosts value to an Array" do
       runner_ssh_called_with_opts = nil
-      Assert.stub(@runner, :ssh){ |_, _, _, o| runner_ssh_called_with_opts = o }
+      Assert.stub(@runner, :ssh){ |_, _, _, _, o| runner_ssh_called_with_opts = o }
 
       host = Factory.string
       subject.instance_eval{ ssh(Factory.string, :hosts => host) }
@@ -457,7 +457,7 @@ module Dk::Task
       assert_equal exp, err.message
 
       exp_cmd_ssh_opts = @default_ssh_cmd_opts.merge(cmd_given_opts)
-      exp = [cmd_str, cmd_input, cmd_given_opts, exp_cmd_ssh_opts]
+      exp = [subject, cmd_str, cmd_input, cmd_given_opts, exp_cmd_ssh_opts]
       assert_equal exp, runner_ssh_called_with
     end
 
@@ -467,7 +467,7 @@ module Dk::Task
       task       = runner.task
 
       runner_ssh_called_with_opts = nil
-      Assert.stub(runner, :ssh){ |_, _, _, o| runner_ssh_called_with_opts = o }
+      Assert.stub(runner, :ssh){ |_, _, _, _, o| runner_ssh_called_with_opts = o }
 
       task.instance_eval{ ssh(Factory.string) }
       assert_equal task_class.ssh_hosts.call, runner_ssh_called_with_opts[:hosts]
@@ -483,7 +483,7 @@ module Dk::Task
       task = runner.task
 
       runner_ssh_called_with_opts = nil
-      Assert.stub(runner, :ssh){ |_, _, _, o| runner_ssh_called_with_opts = o }
+      Assert.stub(runner, :ssh){ |_, _, _, _, o| runner_ssh_called_with_opts = o }
 
       task.instance_eval{ ssh(Factory.string) }
       assert_equal hosts, runner_ssh_called_with_opts[:hosts]
@@ -501,7 +501,7 @@ module Dk::Task
       task = runner.task
 
       runner_ssh_called_with_opts = nil
-      Assert.stub(runner, :ssh){ |_, _, _, o| runner_ssh_called_with_opts = o }
+      Assert.stub(runner, :ssh){ |_, _, _, _, o| runner_ssh_called_with_opts = o }
 
       task.instance_eval{ ssh(Factory.string) }
       assert_equal hosts, runner_ssh_called_with_opts[:hosts]
@@ -518,7 +518,7 @@ module Dk::Task
       task = runner.task
 
       runner_ssh_called_with_opts = nil
-      Assert.stub(runner, :ssh){ |_, _, _, o| runner_ssh_called_with_opts = o }
+      Assert.stub(runner, :ssh){ |_, _, _, _, o| runner_ssh_called_with_opts = o }
 
       task.instance_eval{ ssh(Factory.string, :hosts => hosts_name) }
       assert_equal hosts, runner_ssh_called_with_opts[:hosts]
@@ -531,7 +531,7 @@ module Dk::Task
       task       = runner.task
 
       runner_ssh_called_with_opts = nil
-      Assert.stub(runner, :ssh){ |_, _, _, o| runner_ssh_called_with_opts = o }
+      Assert.stub(runner, :ssh){ |_, _, _, _, o| runner_ssh_called_with_opts = o }
 
       task.instance_eval{ ssh(Factory.string) }
       assert_equal args, runner_ssh_called_with_opts[:ssh_args]
@@ -564,7 +564,7 @@ module Dk::Task
       task       = runner.task
 
       runner_ssh_called_with_opts = nil
-      Assert.stub(runner, :ssh){ |_, _, _, o| runner_ssh_called_with_opts = o }
+      Assert.stub(runner, :ssh){ |_, _, _, _, o| runner_ssh_called_with_opts = o }
 
       task.instance_eval{ ssh(Factory.string) }
       assert_equal args, runner_ssh_called_with_opts[:host_ssh_args]


### PR DESCRIPTION
This allows you to specify the cmd str, input and cmd opts like
the task implementation does.  This makes stubbing cmds that are
driven by dynamic task instance values possible.  If the stubs
are given procs, those procs are instance eval'd against the task
when looking up a matching stub for a cmd.

A side effect of this change is we have to alter the API of the
config/runner stub methods.  The input and opts are now specified
with an hash instead of fuzzy args.  This is b/c we can't evaluate
the fuzzy args and understand them if they are procs.  We can't
tell if a proc is for the input or the cmd opts.

@jcredding ready for review.
