### PR TITLE
add `try_param` task helper and hash method

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Use the `stub_dry_tree_cmd` and `stub_dry_tree_ssh` methods to add cmd and ssh s
 
 The `Dk::Task` mixin provides a bunch of helper methods to make writing tasks easier and for commonizing common functions.
 
-##### `params`, `set_param`, `param?`
+##### `params`, `set_param`, `param?`, `try_param`
 
 ```ruby
 require 'dk/task'
@@ -262,13 +262,18 @@ class MyTask
   include Dk::Task
 
   def run!
-    params['some_param'] #=> "some value"
-    param?('some_param') #=> true
+    param?('some_param')    #=> true
+    params['some_param']    #=> "some value"
+    try_param('some_param') #=> "some value"
 
-    param?('some_other_param') #=> false
+    param?('some_other_param')    #=> false
+    params['some_other_param']    #=> Dk::NoParamError
+    try_param('some_other_param') #=> nil
+
     set_param('some_other_param', 'some other value')
-    params['some_other_param'] #=> "some other value"
-    param?('some_other_param') #=> true
+    param?('some_other_param')    #=> true
+    params['some_other_param']    #=> "some other value"
+    try_param('some_other_param') #=> "some other value"
   end
 
 end
@@ -279,6 +284,8 @@ Use the `param` helper to access named params that the task was run with.  Param
 Use the `set_param` method to set new global param values like you would on the main config.  Any subsequent tasks that are run will have these param values available to them.
 
 Use the `param?` method to check whether a specific param has been set.  Prefer this over `params.key?` as the task params have special logic for interacting with any runner params that makes the traditional `key?` method unreliable.
+
+By default, the params will raise an exception if you try and access a missing key (it will raise Dk::NoParamerror).  The idea is that Dk will loudly notify you if you are accessing a param you expect to be set and it is not set.  However, this may not be appropriate for every scenario, therefore you can use the `try_param` helper and it will just return `nil` if the param is not set.
 
 ##### `before`, `prepend_before`, `after`, `prepend_after`
 

--- a/lib/dk.rb
+++ b/lib/dk.rb
@@ -20,6 +20,7 @@ module Dk
     @config = Config.new
   end
 
-  NoticeError = Class.new(RuntimeError)
+  NoticeError  = Class.new(RuntimeError)
+  NoParamError = Class.new(ArgumentError)
 
 end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -1,5 +1,6 @@
 require 'benchmark'
 require 'set'
+require 'dk'
 require 'dk/ansi'
 require 'dk/config'
 require 'dk/has_set_param'
@@ -25,7 +26,7 @@ module Dk
 
     def initialize(opts = nil)
       opts ||= {}
-      @params = Hash.new{ |h, k| raise ArgumentError, "no param named `#{k}`" }
+      @params = Hash.new{ |h, k| raise Dk::NoParamError, "no param named `#{k}`" }
       @params.merge!(dk_normalize_params(opts[:params]))
 
       d = Config::DEFAULT_CALLBACKS

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -1,10 +1,18 @@
 require 'much-plugin'
+require 'dk'
 require 'dk/remote'
+require 'dk/runner'
 
 module Dk
 
   module Task
     include MuchPlugin
+
+    class ParamsHash < Hash
+      def try_param(key)
+        begin; self.[](key); rescue Dk::NoParamError; nil; end
+      end
+    end
 
     plugin_included do
       include InstanceMethods
@@ -17,7 +25,7 @@ module Dk
       def initialize(runner, params = nil)
         params ||= {}
         @dk_runner = runner
-        @dk_params = Hash.new{ |h, k| @dk_runner.params[k] }
+        @dk_params = ParamsHash.new{ |h, k| @dk_runner.params[k] }
         @dk_params.merge!(params)
       end
 
@@ -95,6 +103,10 @@ module Dk
 
       def param?(key)
         @dk_params.key?(key) || @dk_runner.params.key?(key)
+      end
+
+      def try_param(key)
+        @dk_params.try_param(key)
       end
 
       def before(subject, callback, params = nil)

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'dk/runner'
 
+require 'dk'
 require 'dk/ansi'
 require 'dk/config'
 require 'dk/has_set_param'
@@ -83,7 +84,7 @@ class Dk::Runner
 
     should "use params that complain when accessing missing keys" do
       key = Factory.string
-      assert_raises(ArgumentError){ subject.params[key] }
+      assert_raises(Dk::NoParamError){ subject.params[key] }
 
       subject.params[key] = Factory.string
       assert_nothing_raised{ subject.params[key] }
@@ -265,7 +266,7 @@ class Dk::Runner
       exp = "#{(run_time * 10_000).round / 10.0}ms"
       assert_equal exp, subject.pretty_run_time(run_time)
 
-      run_time = Factory.float(10.0) + 1.0
+      run_time = Factory.float(10.0) + 1.3
       exp = "#{run_time.to_i / 60}:#{(run_time % 60).to_i.to_s.rjust(2, '0')}s"
       assert_equal exp, subject.pretty_run_time(run_time)
     end

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'dk/task'
 
 require 'much-plugin'
+require 'dk'
 require 'dk/remote'
 require 'dk/runner'
 
@@ -601,9 +602,18 @@ module Dk::Task
       p = @runner.params.keys.first
       assert_equal @runner.params[p], subject.instance_eval{ params[p] }
 
-      assert_raises(ArgumentError) do
+      assert_raises(Dk::NoParamError) do
         subject.instance_eval{ params[Factory.string] }
       end
+    end
+
+    should "allow params access that doesn't error if the param is missing" do
+      p = @runner.params.keys.first
+      assert_equal @runner.params[p], subject.instance_eval{ params.try_param(p) }
+      assert_equal @runner.params[p], subject.instance_eval{ try_param(p) }
+
+      assert_nil subject.instance_eval{ params.try_param(Factory.string) }
+      assert_nil subject.instance_eval{ try_param(Factory.string) }
     end
 
     should "call to the runner for `set_param`" do
@@ -626,7 +636,7 @@ module Dk::Task
       p = @task_params.keys.first
       assert_equal @task_params[p], task_w_params.instance_eval{ params[p] }
 
-      assert_raises(ArgumentError) do
+      assert_raises(Dk::NoParamError) do
         task_w_params.instance_eval{ params[Factory.string] }
       end
     end
@@ -637,7 +647,7 @@ module Dk::Task
       subject.instance_eval{ params[p] = val }
 
       assert_equal val, subject.instance_eval{ params[p] }
-      assert_raises(ArgumentError){ @runner.params[p] }
+      assert_raises(Dk::NoParamError){ @runner.params[p] }
     end
 
     should "set a runner (and task) param using `set_param`" do


### PR DESCRIPTION
This method accesses named params but won't error if the param
doesn't exist.  By default, the params hash complains if you try
to access a named param that doesn't exist (using `[]`).  The
idea is that, by default, Dk should warn you if you expect a param
and it isn't there.

However, there are times when you know a param may or may not be
there b/c you control the logic about whether the param is there
and handle things gracefully when it isn't.  For these cases, you
can use this new `try_param` method on the params hash.  If the
param is missing, `nil` is returned.

``` ruby
params['thing'] = 'something'

param?('thing')           #=> true
params['thing']           #=> 'something'
params.try_param('thing') #=> 'something'
try_param('thing')        #=> 'something'

param?('other')           #=> false
params['other']           #=> NoParamError
params.try_param('other') #=> nil
try_param('other')        #=> nil
```

This need specifically came up when stubbing cmds using the API
that takes procs (see PR 66).  Now that all stub procs are eval'd
on each cmd call, if a stub proc access params those params may
not be available yet on early cmd calls.  This allows you to
safely access params in stub procs.

See #66 for reference.

@jcredding ready for review.
