### PR TITLE
add a custom exception for notifying the user of problems

### DIFF
--- a/lib/dk.rb
+++ b/lib/dk.rb
@@ -20,4 +20,6 @@ module Dk
     @config = Config.new
   end
 
+  NoticeError = Class.new(RuntimeError)
+
 end

--- a/lib/dk/cli.rb
+++ b/lib/dk/cli.rb
@@ -46,8 +46,12 @@ module Dk
         @kernel.puts help
         @kernel.puts "\n\n#{exception.message}\n"
         @kernel.exit 1
+      rescue Dk::NoticeError => exception
+        @kernel.puts "\n\n#{exception.message}\n\n"
+        @kernel.puts exception.backtrace.first
+        @kernel.exit 1
       rescue StandardError => exception
-        @kernel.puts "#{exception.class}: #{exception.message}"
+        @kernel.puts "\n\n#{exception.class}: #{exception.message}"
         @kernel.puts exception.backtrace.join("\n")
         @kernel.exit 1
       end


### PR DESCRIPTION
This new `Dk::NoticeError` can be raised in tasks for notifying
the user of a problem.  This stops execution and displays the
exception message on its own followed by the first line of the
backtrace.  The goal is to provide a way to stop execution while
communicating a message to the user (without the full backtrace
causing the message to flow off terminal).

For example:

```
$ dk deploy -d
Starting `deploy`.
      Downloading servers list...
[SSH] cat servers.yaml
      [host1]
      (308.0ms)
      Checking that the `deploy:setup` task has been run...
[SSH] test -d /deploy-dir1 && test -d /deploy-dir1/.git
      [host1]
      [host2]
      (0.1ms)

**** some of the servers are not setup for deploying ****
****       run the `deploy:setup` task first         ****

/path/to/my-dk-deploy/lib/my-dk-deploy/validate_setup.rb:33:in `run!'
```

@jcredding ready for review.
