### PR TITLE
add host info to ssh cmd output lines logs

### DIFF
--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -20,7 +20,7 @@ module Dk
     INDENT_LOG_PREFIX      = '      '.freeze
     CMD_LOG_PREFIX         = '[CMD] '.freeze
     SSH_LOG_PREFIX         = '[SSH] '.freeze
-    CMD_SSH_OUT_LOG_PREFIX = "#{INDENT_LOG_PREFIX}> ".freeze
+    CMD_SSH_OUT_LOG_PREFIX = "> ".freeze
 
     attr_reader :params, :logger
 
@@ -165,7 +165,7 @@ module Dk
       self.logger.info("#{CMD_LOG_PREFIX}#{cmd.cmd_str}")
       block.call(cmd)
       cmd.output_lines.each do |output_line|
-        self.logger.debug("#{CMD_SSH_OUT_LOG_PREFIX}#{output_line.line}")
+        self.logger.debug("#{INDENT_LOG_PREFIX}#{CMD_SSH_OUT_LOG_PREFIX}#{output_line.line}")
       end
       cmd
     end
@@ -189,8 +189,9 @@ module Dk
       end
       time = Benchmark.realtime{ block.call(cmd) }
       self.logger.info("#{INDENT_LOG_PREFIX}(#{self.pretty_run_time(time)})")
-      cmd.output_lines.each do |output_line|
-        self.logger.debug("#{CMD_SSH_OUT_LOG_PREFIX}#{output_line.line}")
+      cmd.output_lines.each do |ol|
+        self.logger.debug "#{INDENT_LOG_PREFIX}[#{ol.host}] " \
+                          "#{CMD_SSH_OUT_LOG_PREFIX}#{ol.line}"
       end
       cmd
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -34,8 +34,7 @@ class Dk::Runner
       assert_equal '      ', subject::INDENT_LOG_PREFIX
       assert_equal '[CMD] ', subject::CMD_LOG_PREFIX
       assert_equal '[SSH] ', subject::SSH_LOG_PREFIX
-
-      assert_equal "#{INDENT_LOG_PREFIX}> ", subject::CMD_SSH_OUT_LOG_PREFIX
+      assert_equal "> ",     subject::CMD_SSH_OUT_LOG_PREFIX
     end
 
   end
@@ -324,7 +323,7 @@ class Dk::Runner
     def exp_log_output(cmd)
       ( ["INFO -- #{CMD_LOG_PREFIX}#{cmd.cmd_str}\n"] +
         cmd.output_lines.map do |ol|
-          "DEBUG -- #{CMD_SSH_OUT_LOG_PREFIX}#{ol.line}\n"
+          "DEBUG -- #{INDENT_LOG_PREFIX}#{CMD_SSH_OUT_LOG_PREFIX}#{ol.line}\n"
         end
       ).join("")
     end
@@ -373,7 +372,7 @@ class Dk::Runner
         cmd.hosts.map{ |h| "INFO -- #{INDENT_LOG_PREFIX}[#{h}]\n" } +
         ["INFO -- #{INDENT_LOG_PREFIX}(#{@pretty_run_time})\n"] +
         cmd.output_lines.map do |ol|
-          "DEBUG -- #{CMD_SSH_OUT_LOG_PREFIX}#{ol.line}\n"
+          "DEBUG -- #{INDENT_LOG_PREFIX}[#{ol.host}] #{CMD_SSH_OUT_LOG_PREFIX}#{ol.line}\n"
         end
       ).join("")
     end


### PR DESCRIPTION
This is to give reference to which host gave which output lines.
For example:

```
      [host1]
      [host2]
      (187.1ms)
      [host1] > repo already cloned
      [host2] > repo already cloned
```

@jcredding ready for review.
