### PR TITLE
add a `start` helper for asynchronously running local system commands

### DIFF
--- a/lib/dk.rb
+++ b/lib/dk.rb
@@ -20,7 +20,8 @@ module Dk
     @config = Config.new
   end
 
-  NoticeError  = Class.new(RuntimeError)
-  NoParamError = Class.new(ArgumentError)
+  NoticeError     = Class.new(RuntimeError)
+  NoParamError    = Class.new(ArgumentError)
+  CmdTimeoutError = Class.new(RuntimeError)
 
 end

--- a/lib/dk/local.rb
+++ b/lib/dk/local.rb
@@ -16,13 +16,34 @@ module Dk::Local
 
     def to_s; self.cmd_str; end
 
+    def start(input = nil)
+      @scmd.start(input)
+      self
+    end
+
+    def wait(timeout = nil)
+      begin
+        @scmd.wait(timeout)
+      rescue Scmd::TimeoutError => e
+        raise Dk::CmdTimeoutError, e.message
+      end
+      self
+    end
+
+    def stop(timeout = nil)
+      @scmd.stop(timeout)
+      self
+    end
+
     def run(input = nil)
       @scmd.run(input)
       self
     end
 
+    def pid;      @scmd.pid;      end
     def stdout;   @scmd.stdout;   end
     def stderr;   @scmd.stderr;   end
+    def running?; @scmd.running?; end
     def success?; @scmd.success?; end
 
     def output_lines
@@ -65,6 +86,11 @@ module Dk::Local
       @cmd_opts = opts
     end
 
+    def start_input
+      return nil unless self.start_called?
+      self.start_calls.first.input
+    end
+
     def run_input
       return nil unless self.run_called?
       self.run_calls.first.input
@@ -73,6 +99,9 @@ module Dk::Local
     def stdout=(value);     @scmd.stdout     = value; end
     def stderr=(value);     @scmd.stderr     = value; end
     def exitstatus=(value); @scmd.exitstatus = value; end
+
+    def start_calls;   @scmd.start_calls;   end
+    def start_called?; @scmd.start_called?; end
 
     def run_calls;   @scmd.run_calls;   end
     def run_called?; @scmd.run_called?; end

--- a/lib/dk/runner.rb
+++ b/lib/dk/runner.rb
@@ -109,12 +109,16 @@ module Dk
       self.logger.debug "===================================="
     end
 
-    def cmd(task, cmd_str, input, given_opts)
-      build_and_run_local_cmd(task, cmd_str, input, given_opts)
+    def start(*args)
+      build_and_start_local_cmd(*args)
     end
 
-    def ssh(task, cmd_str, input, given_opts, ssh_opts)
-      build_and_run_remote_cmd(task, cmd_str, input, given_opts, ssh_opts)
+    def cmd(*args)
+      build_and_run_local_cmd(*args)
+    end
+
+    def ssh(*args)
+      build_and_run_remote_cmd(*args)
     end
 
     def has_run_task?(task_class)
@@ -150,9 +154,17 @@ module Dk
       task_class.new(self, params)
     end
 
-    def build_and_run_local_cmd(task, cmd_str, input, given_opts)
+    def build_and_start_local_cmd(*args)
+      build_and_log_local_cmd(*args){ |cmd, input| cmd.start(input) }
+    end
+
+    def build_and_run_local_cmd(*args)
+      build_and_log_local_cmd(*args){ |cmd, input| cmd.run(input) }
+    end
+
+    def build_and_log_local_cmd(task, cmd_str, input, given_opts, &block)
       local_cmd = build_local_cmd(task, cmd_str, input, given_opts)
-      log_local_cmd(local_cmd){ |cmd| cmd.run(input) }
+      log_local_cmd(local_cmd){ |cmd| block.call(cmd, input) }
     end
 
     # input is needed for the `TestRunner` so it can use it with stubbing

--- a/lib/dk/task.rb
+++ b/lib/dk/task.rb
@@ -65,6 +65,12 @@ module Dk
         @dk_runner.run_task(task_class, params)
       end
 
+      def start(cmd_str, *args)
+        given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
+        input      = args.last
+        @dk_runner.start(self, cmd_str, input, given_opts)
+      end
+
       def cmd(cmd_str, *args)
         given_opts = args.last.kind_of?(::Hash) ? args.pop : nil
         input      = args.last

--- a/lib/dk/test_runner.rb
+++ b/lib/dk/test_runner.rb
@@ -23,14 +23,19 @@ module Dk
       TaskRun.new(task_class, params).tap{ |tr| self.runs << tr }
     end
 
+    # track that a local cmd was started
+    def start(*args)
+      super(*args).tap{ |c| self.runs << c }
+    end
+
     # track that a local cmd was run
-    def cmd(task, cmd_str, input, given_opts)
-      super(task, cmd_str, input, given_opts).tap{ |c| self.runs << c }
+    def cmd(*args)
+      super(*args).tap{ |c| self.runs << c }
     end
 
     # track that a remote cmd was run
-    def ssh(task, cmd_str, input, given_opts, ssh_opts)
-      super(task, cmd_str, input, given_opts, ssh_opts).tap{ |c| self.runs << c }
+    def ssh(*args)
+      super(*args).tap{ |c| self.runs << c }
     end
 
     # test task API

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -56,7 +56,7 @@ class Dk::Runner
     should have_imeths :run, :run_task
     should have_imeths :log_info, :log_debug, :log_error
     should have_imeths :log_task_run, :log_cli_run
-    should have_imeths :cmd, :ssh
+    should have_imeths :start, :cmd, :ssh
     should have_imeths :has_run_task?, :pretty_run_time
 
     should "know its attrs" do
@@ -308,7 +308,20 @@ class Dk::Runner
       Assert.stub(subject, :pretty_run_time){ @pretty_run_time }
     end
 
-    should "build, log and run local cmds" do
+    should "build, log, and start local cmds" do
+      @runner.start(@task, @cmd_str, @cmd_input, @cmd_given_opts)
+
+      exp = [@cmd_str, @cmd_given_opts]
+      assert_equal exp, @local_cmd_new_called_with
+
+      assert_not_nil @local_cmd
+      assert_true @local_cmd.start_called?
+      assert_equal @cmd_input, @local_cmd.start_input
+
+      assert_equal exp_log_output(@local_cmd), @log_out
+    end
+
+    should "build, log, and run local cmds" do
       @runner.cmd(@task, @cmd_str, @cmd_input, @cmd_given_opts)
 
       exp = [@cmd_str, @cmd_given_opts]

--- a/test/unit/task_tests.rb
+++ b/test/unit/task_tests.rb
@@ -290,6 +290,38 @@ module Dk::Task
 
   end
 
+  class StartPrivateHelpersTests < InitTests
+
+    should "start local cmds, calling to the runner" do
+      runner_start_called_with = nil
+      Assert.stub(@runner, :start) do |*args|
+        runner_start_called_with = args
+        Assert.stub_send(@runner, :start, *args)
+      end
+
+      cmd_str   = Factory.string
+      cmd_input = Factory.string
+      cmd_opts  = { Factory.string => Factory.string }
+
+      subject.instance_eval{ start(cmd_str, cmd_input, cmd_opts) }
+      exp = [subject, cmd_str, cmd_input, cmd_opts]
+      assert_equal exp, runner_start_called_with
+
+      subject.instance_eval{ start(cmd_str) }
+      exp = [subject, cmd_str, nil, nil]
+      assert_equal exp, runner_start_called_with
+
+      subject.instance_eval{ start(cmd_str, cmd_input) }
+      exp = [subject, cmd_str, cmd_input, nil]
+      assert_equal exp, runner_start_called_with
+
+      subject.instance_eval{ start(cmd_str, cmd_opts) }
+      exp = [subject, cmd_str, nil, cmd_opts]
+      assert_equal exp, runner_start_called_with
+    end
+
+  end
+
   class CmdPrivateHelpersTests < InitTests
 
     should "run local cmds, calling to the runner" do


### PR DESCRIPTION
This complements the `cmd` and `cmd!` helpers. Like those, this
runs a local system command but it doesn't block waiting on an
exitstatus.

This is handy for running system commands that run while you also
run additional system commands. The classic example would be
running a server, then running other system commands that interact
with that server, and finally running a command to signal that
server to shutdown. In this example you would use `start` to run
the local server and use `cmd`/`cmd!` to interact with and shutdown
the server.

This also includes all the support logic for this new helper to
make it work just like `cmd`/`cmd!`: spy logic, test runner, etc.

@jcredding ready for review.